### PR TITLE
demrepofdave/issue_002: no menu on certain linux distros f11 key overriden by os

### DIFF
--- a/src/linux-keydefine.c
+++ b/src/linux-keydefine.c
@@ -356,7 +356,7 @@ DIALOG bemdefinegui[] =
         {d_button_proc, 205,232,60,28,  FG,BG,  0,   D_CLOSE, 1,  0,              "OK",     NULL,      NULL},
         {d_button_proc, 271,232,60,28,  FG,BG,  0,   D_CLOSE, 0,  0,              "Cancel", NULL,      NULL},
 
-        {d_getkey,      8,8,522,28,     FG,BG,  0,   D_EXIT,  0,  KEY_F10,       "Menu",   NULL,      NULL},
+        {d_getkey,      8,8,522,28,     FG,BG,  0,   D_EXIT,  0,  KEY_HOME,       "Menu",   NULL,      NULL},
 
         {d_getkey,      26,56,28,28,    FG,BG,  0,   D_EXIT,  0,  KEY_ESC,        "ESC",    NULL,      NULL},
         {d_getkey,      58,56,28,28,    FG,BG,  0,   D_EXIT,  0,  KEY_1,          "1",      NULL,      NULL},

--- a/src/linux-keydefine.c
+++ b/src/linux-keydefine.c
@@ -356,7 +356,7 @@ DIALOG bemdefinegui[] =
         {d_button_proc, 205,232,60,28,  FG,BG,  0,   D_CLOSE, 1,  0,              "OK",     NULL,      NULL},
         {d_button_proc, 271,232,60,28,  FG,BG,  0,   D_CLOSE, 0,  0,              "Cancel", NULL,      NULL},
 
-        {d_getkey,      8,8,522,28,     FG,BG,  0,   D_EXIT,  0,  KEY_MENU,       "Menu",   NULL,      NULL},
+        {d_getkey,      8,8,522,28,     FG,BG,  0,   D_EXIT,  0,  KEY_F10,       "Menu",   NULL,      NULL},
 
         {d_getkey,      26,56,28,28,    FG,BG,  0,   D_EXIT,  0,  KEY_ESC,        "ESC",    NULL,      NULL},
         {d_getkey,      58,56,28,28,    FG,BG,  0,   D_EXIT,  0,  KEY_1,          "1",      NULL,      NULL},
@@ -477,7 +477,7 @@ void update_break_keys()
 
 void update_menu_keys()
 {
-        update_special_keys(menu_keys, KEY_MENU);
+        update_special_keys(menu_keys, KEY_HOME);
 }
 
 static int special_key_pressed(int special_keys[MAX_KEYS])

--- a/src/linux.c
+++ b/src/linux.c
@@ -28,6 +28,13 @@ char discname2[260];
 int quited=0;
 int infocus=1;
 
+
+
+void native_window_close_button_handler(void)
+{
+       quited = 1;
+}
+
 void startblit()
 {
 }
@@ -46,6 +53,8 @@ int main(int argc, char *argv[])
                 exit(-1);
         }
         initelk(argc,argv);
+        set_window_title("Elkulator 1.0 (Press HOME for menu)");
+        set_close_button_callback(native_window_close_button_handler);
         install_mouse();
         while (!quited)
         {

--- a/src/win-keydefine.c
+++ b/src/win-keydefine.c
@@ -301,7 +301,7 @@ int break_pressed()
 
 int menu_pressed()
 {
-        return key[KEY_F11];
+        return key[HOME];
 }
 
 #endif


### PR DESCRIPTION
- Menu key on linux has been redefined as the Home key.
- Windows menu key has also been redefined but unable to test to confirm this at the moment.
- Added notification that home key is the menu key to the native windows title (note - this will need to be improved, currently this is fixed even if the menu key is redefined).
- Also fixed linux so that close button on native window will terminate Elkulator