### PR TITLE
Demrepofdave/al5int/serial parallel support

### DIFF
--- a/.github/workflows/ci-elkulator-linux.yml
+++ b/.github/workflows/ci-elkulator-linux.yml
@@ -2,28 +2,6 @@ name: Check and Build Elkulator
 run-name: CI Build for Linux Elkulator requested by ${{ github.actor }}
 on: [push]
 jobs:
-  build-allegro4-ubuntu2004:
-    runs-on: ubuntu-20.04
-    steps:
-      - run: echo "This job running on a ${{ runner.os }}, triggered by ${{ github.event_name }} event."
-      - run: echo "Branch is ${{ github.ref }}, repository is ${{ github.repository }}."
-      - name: Install required apt files
-        run: |
-         sudo apt-get update
-         sudo apt-get install -y automake liballegro4-dev zlib1g-dev libalut-dev libopenal-dev cppcheck
-      - name: Check out repository code
-        uses: actions/checkout@v4
-      - name: List files in the repository
-        run: |
-          ls ${{ github.workspace }}
-      - name: Configure
-        run: ./scripts/autoconfigure.sh --enable-allegro4
-      - name: Check source (cppcheck)
-        run: cppcheck .
-      - name: Build source
-        run: make elkulator
-      - run: echo "Job Complete.  Status job ${{ job.status }}."
-
   build-allegro4-ubuntu2204:
     runs-on: ubuntu-22.04
     steps:
@@ -62,26 +40,6 @@ jobs:
           ls ${{ github.workspace }}
       - name: Configure
         run: ./scripts/autoconfigure.sh --enable-allegro4
-      - name: Check source (cppcheck)
-        run: cppcheck .
-      - name: Build source
-        run: make elkulator
-      - run: echo "Job Complete.  Status job ${{ job.status }}."
-
-  build-allegro5-ubuntu2004:
-    runs-on: ubuntu-20.04
-    steps:
-      - run: echo "This job running on a ${{ runner.os }}, triggered by ${{ github.event_name }} event."
-      - run: echo "Branch is ${{ github.ref }}, repository is ${{ github.repository }}."
-      - name: Install required apt files
-        run: |
-         sudo add-apt-repository ppa:allegro/5.2
-         sudo apt-get update
-         sudo apt-get install -y automake liballegro5-dev zlib1g-dev libalut-dev libopenal-dev cppcheck
-      - name: Check out repository code
-        uses: actions/checkout@v4
-      - name: Configure
-        run: ./scripts/autoconfigure.sh
       - name: Check source (cppcheck)
         run: cppcheck .
       - name: Build source

--- a/Makefile.am
+++ b/Makefile.am
@@ -56,6 +56,7 @@ elkulator_hal_src = src/host_abstraction_layer/allegro_5/adc.c  \
                     src/host_abstraction_layer/allegro_5/palfilt.c \
                     src/host_abstraction_layer/allegro_5/samples.c \
                     src/host_abstraction_layer/allegro_5/scale2x.c \
+                    src/host_abstraction_layer/allegro_5/2xsai.c \
                     src/host_abstraction_layer/allegro_5/soundopenal.c \
                     src/host_abstraction_layer/allegro_5/video.c \
                     src/host_abstraction_layer/allegro_5/keyboard_gui.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,9 +17,9 @@ elkulator_CFLAGS = $(allegro_CFLAGS) -I ./src/ -Wno-unused-result
 
 # workaround for Win32 Allegro, which has `allegro-config' missing
 if OS_WIN
-elkulator_LDADD = -lalleg -lz -lopenal -lalut -lallegro_main
+elkulator_LDADD = -lalleg -lz -lopenal -lalut
 else
-elkulator_LDADD = $(allegro_LIBS) -lz -lopenal -lalut -lz -lallegro_main
+elkulator_LDADD = $(allegro_LIBS) -lz -lopenal -lalut -lz
 endif
 
 if ENABLE_ALLEGRO4

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,9 +17,9 @@ elkulator_CFLAGS = $(allegro_CFLAGS) -I ./src/ -Wno-unused-result
 
 # workaround for Win32 Allegro, which has `allegro-config' missing
 if OS_WIN
-elkulator_LDADD = -lalleg -lz -lopenal -lalut
+elkulator_LDADD = -lalleg -lz -lopenal -lalut -lallegro_main
 else
-elkulator_LDADD = $(allegro_LIBS) -lz -lopenal -lalut -lz
+elkulator_LDADD = $(allegro_LIBS) -lz -lopenal -lalut -lz -lallegro_main
 endif
 
 if ENABLE_ALLEGRO4

--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,7 @@ else
    AC_CHECK_HEADER([allegro5/allegro.h],[],
 	    [AC_MSG_FAILURE([The Allegro version 5 library is needed but not installed], 1)],[])
    AC_CHECK_LIB([allegro], [al_install_system])
+   AC_CHECK_LIB([allegro_main], [al_install_system])
    AC_CHECK_LIB([allegro_acodec], [al_init_acodec_addon])
    AC_CHECK_LIB([allegro_audio], [al_install_audio])
    AC_CHECK_LIB([allegro_dialog], [al_init_native_dialog_addon])

--- a/src/elk.h
+++ b/src/elk.h
@@ -27,7 +27,7 @@ extern "C" {
 
 #define printf rpclog
 
-#define VERSION_STR "Elkulator v2.00b-0119"
+#define VERSION_STR "Elkulator v2.00b-0511"
 
 void rpclog(char *format, ...);
 

--- a/src/host_abstraction_layer/allegro_5/2xsai.c
+++ b/src/host_abstraction_layer/allegro_5/2xsai.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <allegro5/allegro.h>
 //#include <allegro/internal/aintern.h>
+#include <allegro5/allegro_primitives.h>
 #include "video_internal.h"
 #include "logger.h"
 
@@ -19,6 +20,22 @@ static int xsai_depth = 0;
 
 typedef uint32_t elk_pallete_t;
 extern elk_pallete_t elkpal[8];
+
+// TODO: Raid allegro4 code for implementation.
+int makecol_depth(int depth, int r, int g, int b){
+    switch (depth){
+        //case 8: return bestfit_color(current_palette, r>>2, g>>2, b>>2);
+        case 15: return (r >> 3) + ((g >> 3) << 5) + ((b >> 3) << 10);
+        case 16: return (r >> 3) + ((g >> 2) << 5) + ((b >> 3) << 11);
+        case 24: return r + (g << 8) + (b << 16);
+        case 32: return r + (g << 8) + (b << 16) + (255 << 24);
+        default: return 0;
+    }
+}
+
+int makecol(int r, int g, int b){
+    return makecol_depth(32, r, g, b); // TODO: Check code here.
+}
 
 int Init_2xSaI(int d)
 {
@@ -46,10 +63,11 @@ int Init_2xSaI(int d)
 	redblueMask = makecol_depth(d, 255, 0, 255);
 	greenMask = makecol_depth(d, 0, 255, 0);
 
-	TRACE("Color Mask:       0x%lX\n", colorMask);
-	TRACE("Low Pixel Mask:   0x%lX\n", lowPixelMask);
-	TRACE("QColor Mask:      0x%lX\n", qcolorMask);
-	TRACE("QLow Pixel Mask:  0x%lX\n", qlowpixelMask);
+	log_debug("Color Depth:      %d\n", d);
+	log_debug("Color Mask:       0x%lX\n", colorMask);
+	log_debug("Low Pixel Mask:   0x%lX\n", lowPixelMask);
+	log_debug("QColor Mask:      0x%lX\n", qcolorMask);
+	log_debug("QLow Pixel Mask:  0x%lX\n", qlowpixelMask);
 	
 	xsai_depth = d;
 
@@ -110,7 +128,7 @@ static uint8_t *src_line[4];
 static uint8_t *dst_line[2];
 
 
-void Super2xSaI(ALLEGRO_BITMAP * bitmapDest, uint8_t * elk_screen_data, int w, int h)
+void Super2xSaI(uint8_t * elk_screen_data, ALLEGRO_BITMAP * bitmapDest, int w, int h)
 {
 	Super2xSaI_ex(elk_screen_data, bitmapDest, w, h);
 	return;
@@ -118,7 +136,6 @@ void Super2xSaI(ALLEGRO_BITMAP * bitmapDest, uint8_t * elk_screen_data, int w, i
 
 void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, uint32 height) 
 {
-	int j, v;
 	unsigned int x, y;
 	uint32_t color[16];
 
@@ -127,14 +144,16 @@ void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width
 	src_line[1] = elk_screen_data;
 	src_line[2] = elk_screen_data + width;
 	src_line[3] = elk_screen_data + (width * 2);
-
-	/* Can we write the results directly? */
-	dst_line[0] = dest->line[0];
-	dst_line[1] = dest->line[1];
-	v = 0;
 	
 	/* Set destination */
-	bmp_select(dest);
+	//bmp_select(dest);
+    uint8_t * region_data_line = NULL;
+	ALLEGRO_LOCKED_REGION * destRegion = al_lock_bitmap(dest, ALLEGRO_PIXEL_FORMAT_ARGB_8888, ALLEGRO_LOCK_WRITEONLY);
+    region_data_line = (uint8_t *)destRegion->data;
+
+	/* Can we write the results directly? */
+	dst_line[0] = (uint8 *)region_data_line;
+	dst_line[1] = (uint8 *)region_data_line + destRegion->pitch;
 
 	x = 0, y = 0;
 	
@@ -287,16 +306,11 @@ void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width
 		
 		/* Write the 2 lines, if not already done so */
 		if (y < height - 1) {
-			dst_line[0] = dest->line[y * 2 + 2];
-			dst_line[1] = dest->line[y * 2 + 3];
+			dst_line[0] = region_data_line + (destRegion->pitch * (y + 2));
+			dst_line[1] = region_data_line + (destRegion->pitch * (y + 3));
 		}
 	}
-	//bmp_unwrite_line(dest);
-	
-	if (v) {
-		free(dst_line[0]);
-		free(dst_line[1]);
-	}
+	al_unlock_bitmap(dest);
 }
 
 

--- a/src/host_abstraction_layer/allegro_5/2xsai.c
+++ b/src/host_abstraction_layer/allegro_5/2xsai.c
@@ -128,13 +128,7 @@ static uint8_t *src_line[4];
 static uint8_t *dst_line[2];
 
 
-void Super2xSaI(uint8_t * elk_screen_data, ALLEGRO_BITMAP * bitmapDest, int w, int h)
-{
-	Super2xSaI_ex(elk_screen_data, bitmapDest, w, h);
-	return;
-}
-
-void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, uint32 height) 
+void Super2xSaI(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, uint32 height) 
 {
 	unsigned int x, y;
 	uint32_t color[16];
@@ -251,10 +245,10 @@ void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width
             *((uint32_t *) (&dst_line[1][x * 8])) = product2a;
             *((uint32_t *) (&dst_line[1][x * 8 + 4])) = product2b;
 			// TODO: Following does not work yet.
-			*((uint32_t *) (&dst_line[0][x * 8]) + destRegion->pitch) = product1a;
-            *((uint32_t *) (&dst_line[0][x * 8 + 4]) + destRegion->pitch) = product1b;
-            *((uint32_t *) (&dst_line[1][x * 8]) + destRegion->pitch) = product2a;
-            *((uint32_t *) (&dst_line[1][x * 8 + 4])+ destRegion->pitch) = product2b;
+			//*((uint32_t *) (&dst_line[0][x * 8]) + destRegion->pitch) = product1a;
+            //*((uint32_t *) (&dst_line[0][x * 8 + 4]) + destRegion->pitch) = product1b;
+            //*((uint32_t *) (&dst_line[1][x * 8]) + destRegion->pitch) = product2a;
+            //*((uint32_t *) (&dst_line[1][x * 8 + 4])+ destRegion->pitch) = product2b;
 			
 			/* Move color matrix forward */
 			color[0] = color[1]; color[4] = color[5]; color[8] = color[9];   color[12] = color[13];
@@ -325,12 +319,7 @@ void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width
 
 
 
-void SuperEagle(uint8_t * elk_screen_data, ALLEGRO_BITMAP * bitmapDest, int w, int h)
-{
-	SuperEagle_ex(elk_screen_data, bitmapDest, w, h);
-}
-
-void SuperEagle_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, uint32 height)
+void SuperEagle(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, uint32 height)
 {
 
 	int j, v;
@@ -513,4 +502,5 @@ void SuperEagle_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width
 			dst_line[1] = region_data_line + dest_pitch_y_plus_3;
 		}
 	}
+    al_unlock_bitmap(dest);
 }

--- a/src/host_abstraction_layer/allegro_5/2xsai.c
+++ b/src/host_abstraction_layer/allegro_5/2xsai.c
@@ -430,11 +430,11 @@ void SuperEagle(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, u
 			}
 
             *((uint32_t *) (&dst_line[0][x * 8])) = product1a;
-            *((uint32_t *) (&dst_line[0][x * 8 + 4])) = product1b;
+            *((uint32_t *) (&dst_line[0][(x * 8) + 4])) = product1b;
             *((uint32_t *) (&dst_line[1][x * 8])) = product2a;
-            *((uint32_t *) (&dst_line[1][x * 8 + 4])) = product2b;
+            *((uint32_t *) (&dst_line[1][(x * 8) + 4])) = product2b;
 			
-			/* Move color matrix forward */
+            *((uint32_t *) (&dst_line[0][x * 8])) = elkpal[*(src_line[0]+x)];
 			color[0] = color[1]; 
 			color[2] = color[3]; color[3] = color[4]; color[4] = color[5];
 			color[6] = color[7]; color[7] = color[8]; color[8] = color[9]; 
@@ -442,12 +442,12 @@ void SuperEagle(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, u
 			
 			if (x < width - 2) {
 				x += 2;
-                color[1] = *(((uint32_t*)src_line[0]) + x);
+                color[1] = elkpal[*(src_line[0] + x)];
                 if (x < width) {
-                    color[5] = *(((uint32_t*)src_line[1]) + x + 1);
-                    color[9] = *(((uint32_t*)src_line[2]) + x + 1);
+                    color[5] = elkpal[*(src_line[1] + x + 1)];
+                    color[9] = elkpal[*(src_line[2] + x + 1)];
                 }
-                color[11] = *(((uint32_t*)src_line[3]) + x);
+                color[11] = elkpal[*(src_line[3] + x)];
 				x -= 2;
 			}
 		}

--- a/src/host_abstraction_layer/allegro_5/2xsai.c
+++ b/src/host_abstraction_layer/allegro_5/2xsai.c
@@ -2,6 +2,7 @@
 #include <allegro5/allegro.h>
 //#include <allegro/internal/aintern.h>
 #include "video_internal.h"
+#include "logger.h"
 
 //#define TRACE rpclog
 #define uint32 unsigned long
@@ -16,7 +17,8 @@ static uint32 redblueMask = 0xF81F;
 static uint32 greenMask = 0x7E0;
 static int xsai_depth = 0;
 
-
+typedef uint32_t elk_pallete_t;
+extern elk_pallete_t elkpal[8];
 
 int Init_2xSaI(int d)
 {
@@ -104,122 +106,58 @@ static int GetResult2(uint32 A, uint32 B, uint32 C, uint32 D, uint32 E)
 	+ ((((A & qlowpixelMask) + (B & qlowpixelMask) + (C & qlowpixelMask) + (D & qlowpixelMask)) >> 2) & qlowpixelMask)
 
 
-/* Clipping Macro, stolen from Allegro, modified to work with 2xSaI */
-#define BLIT_CLIP2(src, dest, s_x, s_y, d_x, d_y, w, h, xscale, yscale)      \
-   /* check for ridiculous cases */                                          \
-   if ((s_x >= src->cr) || (s_y >= src->cb) ||                               \
-       (d_x >= dest->cr) || (d_y >= dest->cb))                               \
-      return;                                                                \
-                                                                             \
-   if ((s_x + w < src->cl) || (s_y + h < src->ct) ||                         \
-       (d_x + w * xscale < dest->cl) || (d_y + h * yscale < dest->ct))       \
-      return;                                                                \
-                                                                             \
-   if (xscale < 1 || yscale < 1)                                             \
-      return;                                                                \
-                                                                             \
-   /* clip src left */                                                       \
-   if (s_x < src->cl) {                                                      \
-      w += s_x;                                                              \
-      d_x -= s_x * xscale;                                                   \
-      s_x = src->cl;                                                         \
-   }                                                                         \
-                                                                             \
-   /* clip src top */                                                        \
-   if (s_y < src->ct) {                                                      \
-      h += s_y;                                                              \
-      d_y -= s_y * yscale;                                                   \
-      s_y = src->ct;                                                         \
-   }                                                                         \
-                                                                             \
-   /* clip src right */                                                      \
-   if (s_x + w > src->cr)                                                    \
-      w = src->cr - s_x;                                                     \
-                                                                             \
-   /* clip src bottom */                                                     \
-   if (s_y + h > src->cb)                                                    \
-      h = src->cb - s_y;                                                     \
-                                                                             \
-   /* clip dest left */                                                      \
-   if (d_x < dest->cl) {                                                     \
-      d_x -= dest->cl;                                                       \
-      w += d_x / xscale;                                                     \
-      s_x -= d_x / xscale;                                                   \
-      d_x = dest->cl;                                                        \
-   }                                                                         \
-                                                                             \
-   /* clip dest top */                                                       \
-   if (d_y < dest->ct) {                                                     \
-      d_y -= dest->ct;                                                       \
-      h += d_y / yscale;                                                     \
-      s_y -= d_y / yscale;                                                   \
-      d_y = dest->ct;                                                        \
-   }                                                                         \
-                                                                             \
-   /* clip dest right */                                                     \
-   if (d_x + w * xscale > dest->cr)                                          \
-      w = (dest->cr - d_x) / xscale;                                         \
-                                                                             \
-   /* clip dest bottom */                                                    \
-   if (d_y + h * yscale > dest->cb)                                          \
-      h = (dest->cb - d_y) / yscale;                                         \
-                                                                             \
-   /* bottle out if zero size */                                             \
-   if ((w <= 0) || (h <= 0))                                                 \
-      return;
-
-
 static uint8_t *src_line[4];
 static uint8_t *dst_line[2];
 
 
-void Super2xSaI(ALLEGRO_BITMAP * bitmapDest, uint8_t * elk_screen_data, int s_x, int s_y, int d_x, int d_y, int w, int h)
+void Super2xSaI(ALLEGRO_BITMAP * bitmapDest, uint8_t * elk_screen_data, int w, int h)
 {
-	int sbpp, dbpp;
-
-	Super2xSaI_ex(elk_screen_data, (unsigned int)(bitmapSource->line[1] - bitmapSource->line[0]), NULL, bitmapDest, w, h);
-	
+	Super2xSaI_ex(elk_screen_data, bitmapDest, w, h);
 	return;
 }
 
-void Super2xSaI_ex(uint8_t * elk_screen_data, uint32 src_pitch, uint8 *unused, ALLEGRO_BITMAP *dest, uint32 width, uint32 height) 
+void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, uint32 height) 
 {
 	int j, v;
 	unsigned int x, y;
-	int sbpp = BYTES_PER_PIXEL(bitmap_color_depth(dest));
 	uint32_t color[16];
 
 	/* Point to the first 3 lines. */
-	src_line[0] = src;
-	src_line[1] = src;
-	src_line[2] = src + src_pitch;
-	src_line[3] = src + src_pitch * 2;
+	src_line[0] = elk_screen_data;
+	src_line[1] = elk_screen_data;
+	src_line[2] = elk_screen_data + width;
+	src_line[3] = elk_screen_data + (width * 2);
 
 	/* Can we write the results directly? */
-	if (is_video_bitmap(dest) || is_planar_bitmap(dest)) {
-		dst_line[0] = malloc(sizeof(char) * sbpp * width);
-		dst_line[1] = malloc(sizeof(char) * sbpp * width);
-		v = 1;
-	}
-	else {
-		dst_line[0] = dest->line[0];
-		dst_line[1] = dest->line[1];
-		v = 0;
-	}
+	dst_line[0] = dest->line[0];
+	dst_line[1] = dest->line[1];
+	v = 0;
 	
 	/* Set destination */
 	bmp_select(dest);
 
 	x = 0, y = 0;
 	
-    uint32_t *lbp;
-    lbp = (uint32_t*)src_line[0];
-    color[0] = *lbp;       color[1] = color[0];   color[2] = color[0];    color[3] = color[0];
-    color[4] = color[0];   color[5] = color[0];   color[6] = *(lbp + 1);  color[7] = *(lbp + 2);
-    lbp = (uint32_t*)src_line[2];
-    color[8] = *lbp;     color[9] = color[8];     color[10] = *(lbp + 1); color[11] = *(lbp + 2);
-    lbp = (uint32_t*)src_line[3];
-    color[12] = *lbp;    color[13] = color[12];   color[14] = *(lbp + 1); color[15] = *(lbp + 2);
+    uint32_t lbp, lbp1, lbp2;
+
+    lbp  = elkpal[*src_line[0]];
+	lbp1 = elkpal[*(src_line[0] + 1)];
+	lbp2 = elkpal[*(src_line[0] + 2)];
+
+    color[0] = lbp;       color[1] = color[0];   color[2] = color[0];    color[3] = color[0];
+    color[4] = color[0];  color[5] = color[0];   color[6] = lbp1;  color[7] = lbp2;
+
+	lbp  = elkpal[*src_line[2]];
+	lbp1 = elkpal[*(src_line[2] + 1)];
+	lbp2 = elkpal[*(src_line[2] + 2)];
+
+    color[8] = lbp;     color[9] = color[8];     color[10] = lbp1; color[11] = lbp2;
+
+	lbp  = elkpal[*src_line[3]];
+	lbp1 = elkpal[*(src_line[3] + 1)];
+	lbp2 = elkpal[*(src_line[3] + 2)];
+
+    color[12] = lbp;    color[13] = color[12];   color[14] = lbp1; color[15] = lbp2;
 
 	for (y = 0; y < height; y++) {
 	
@@ -302,10 +240,10 @@ void Super2xSaI_ex(uint8_t * elk_screen_data, uint32 src_pitch, uint8 *unused, A
 			if (x < width - 3) {
 				x += 3;
 
-    			color[3] = *(((uint32_t*)src_line[0]) + x);
-				color[7] = *(((uint32_t*)src_line[1]) + x);
-				color[11] = *(((uint32_t*)src_line[2]) + x);
-				color[15] = *(((uint32_t*)src_line[3]) + x);
+    			color[3]  = elkpal[*(src_line[0] + x)];
+				color[7]  = elkpal[*(src_line[1] + x)];
+				color[11] = elkpal[*(src_line[2] + x)];
+				color[15] = elkpal[*(src_line[3] + x)];
 
 				x -= 3;
 			}
@@ -320,39 +258,40 @@ void Super2xSaI_ex(uint8_t * elk_screen_data, uint32 src_pitch, uint8 *unused, A
 		if (y + 3 >= height)
 			src_line[3] = src_line[2];
 		else
-			src_line[3] = src_line[2] + src_pitch;
+			src_line[3] = src_line[2] + width;
 			
 		/* Then shift the color matrix up */
-    	uint32_t *lbp;
-		lbp = (uint32_t*)src_line[0];
-		color[0] = *lbp;     color[1] = color[0];    color[2] = *(lbp + 1);  color[3] = *(lbp + 2);
-		lbp = (uint32_t*)src_line[1];
-		color[4] = *lbp;     color[5] = color[4];    color[6] = *(lbp + 1);  color[7] = *(lbp + 2);
-		lbp = (uint32_t*)src_line[2];
-		color[8] = *lbp;     color[9] = color[9];    color[10] = *(lbp + 1); color[11] = *(lbp + 2);
-		lbp = (uint32_t*)src_line[3];
-		color[12] = *lbp;    color[13] = color[12];  color[14] = *(lbp + 1); color[15] = *(lbp + 2);
+		lbp  = elkpal[*src_line[0]];
+		lbp1 = elkpal[*(src_line[0] + 1)];
+		lbp2 = elkpal[*(src_line[0] + 2)];
+
+		color[0] = lbp;     color[1] = color[0];    color[2] = lbp1;  color[3] = lbp2;
+
+		lbp  = elkpal[*src_line[1]];
+		lbp1 = elkpal[*(src_line[1] + 1)];
+		lbp2 = elkpal[*(src_line[1] + 2)];
+
+		color[4] = lbp;     color[5] = color[4];    color[6] = lbp1;  color[7] = lbp2;
+
+		lbp  = elkpal[*src_line[2]];
+		lbp1 = elkpal[*(src_line[2] + 1)];
+		lbp2 = elkpal[*(src_line[2] + 2)];
+
+		color[8] = lbp;     color[9] = color[9];    color[10] = lbp1; color[11] = lbp2;
+
+		lbp  = elkpal[*src_line[3]];
+		lbp1 = elkpal[*(src_line[3] + 1)];
+		lbp2 = elkpal[*(src_line[3] + 2)];
+
+		color[12] = lbp;    color[13] = color[12];  color[14] = lbp1; color[15] = lbp2;
 		
 		/* Write the 2 lines, if not already done so */
-		if (v) {
-			uint32_t dst_addr;
-		
-			dst_addr = bmp_write_line(dest, y * 2);
-			for (j = 0; j < dest->w * sbpp; j += sizeof(long))
-				bmp_write32(dst_addr + j, *((uint32_t *) (dst_line[0] + j)));
-				
-			dst_addr = bmp_write_line(dest, y * 2 + 1);
-			for (j = 0; j < dest->w * sbpp; j += sizeof(long))
-				bmp_write32(dst_addr + j, *((uint32_t *) (dst_line[1] + j)));
-		}
-		else {
-			if (y < height - 1) {
-				dst_line[0] = dest->line[y * 2 + 2];
-				dst_line[1] = dest->line[y * 2 + 3];
-			}
+		if (y < height - 1) {
+			dst_line[0] = dest->line[y * 2 + 2];
+			dst_line[1] = dest->line[y * 2 + 3];
 		}
 	}
-	bmp_unwrite_line(dest);
+	//bmp_unwrite_line(dest);
 	
 	if (v) {
 		free(dst_line[0]);
@@ -362,217 +301,215 @@ void Super2xSaI_ex(uint8_t * elk_screen_data, uint32 src_pitch, uint8 *unused, A
 
 
 
-void SuperEagle(ALLEGRO_BITMAP * bitmapSource, ALLEGRO_BITMAP * bitmapDest, int s_x, int s_y, int d_x, int d_y, int w, int h)
-{
-	int sbpp, dbpp;
+//void SuperEagle(ALLEGRO_BITMAP * bitmapSource, ALLEGRO_BITMAP * bitmapDest, int s_x, int s_y, int d_x, int d_y, int w, int h)
+//{
+//	int sbpp, dbpp;
 
-	ALLEGRO_BITMAP * dst2         = NULL;
+//	ALLEGRO_BITMAP * dst2         = NULL;
 
-	if (!bitmapSource || !bitmapDest)
-		return;
+//	if (!bitmapSource || !bitmapDest)
+//		return;
 
-	sbpp = bitmap_color_depth(bitmapSource);
-	dbpp = bitmap_color_depth(bitmapDest);
+//	sbpp = bitmap_color_depth(bitmapSource);
+//	dbpp = bitmap_color_depth(bitmapDest);
 
-	if ((sbpp != xsai_depth) || (sbpp != dbpp))	/* Must be same color depth */
-		return;
-
-//	BLIT_CLIP2(src, dest, s_x, s_y, d_x, d_y, w, h, 2, 2);
+//	if ((sbpp != xsai_depth) || (sbpp != dbpp))	/* Must be same color depth */
+//		return;
 		
-	if (w < 4 || h < 4) {  /* Image is too small to be 2xSaI'ed. */
-		stretch_blit(bitmapSource, bitmapDest, s_x, s_y, w, h, d_x, d_y, w * 2, h * 2);
-		return;
-	}	
+//	if (w < 4 || h < 4) {  /* Image is too small to be 2xSaI'ed. */
+//		stretch_blit(bitmapSource, bitmapDest, s_x, s_y, w, h, d_x, d_y, w * 2, h * 2);
+//		return;
+//	}	
 	
-	sbpp = BYTES_PER_PIXEL(sbpp);
-	if (d_x || d_y)
-		dst2 = create_sub_bitmap(bitmapDest, d_x, d_y, w * 2, h * 2);
+//	sbpp = BYTES_PER_PIXEL(sbpp);
+//	if (d_x || d_y)
+//		dst2 = create_sub_bitmap(bitmapDest, d_x, d_y, w * 2, h * 2);
 	
-	SuperEagle_ex(bitmapSource->line[s_y] + s_x * sbpp, (unsigned int)(bitmapSource->line[1] - bitmapSource->line[0]), NULL, dst2 ? dst2 : bitmapDest, w, h);
+//	SuperEagle_ex(bitmapSource->line[s_y] + s_x * sbpp, (unsigned int)(bitmapSource->line[1] - bitmapSource->line[0]), NULL, dst2 ? dst2 : bitmapDest, w, h);
 	
-	if (dst2)
-		destroy_bitmap(dst2);
+//	if (dst2)
+//		destroy_bitmap(dst2);
 	
-	return;
-}
+//	return;
+//}
 
-void SuperEagle_ex(uint8 *src, uint32 src_pitch, uint8 *unused, ALLEGRO_BITMAP *dest, uint32 width, uint32 height) {
+//void SuperEagle_ex(uint8 *src, uint32 src_pitch, uint8 *unused, ALLEGRO_BITMAP *dest, uint32 width, uint32 height) {
 
-	int j, v;
-	unsigned int x, y;
-	int sbpp = BYTES_PER_PIXEL(bitmap_color_depth(dest));
-	uint32_t color[12];
+//	int j, v;
+//	unsigned int x, y;
+//	int sbpp = BYTES_PER_PIXEL(bitmap_color_depth(dest));
+//	uint32_t color[12];
 
 	/* Point to the first 3 lines. */
-	src_line[0] = src;
-	src_line[1] = src;
-	src_line[2] = src + src_pitch;
-	src_line[3] = src + src_pitch * 2;
+//	src_line[0] = src;
+//	src_line[1] = src;
+//	src_line[2] = src + src_pitch;
+//	src_line[3] = src + src_pitch * 2;
 	
 	/* Can we write the results directly? */
-	if (is_video_bitmap(dest) || is_planar_bitmap(dest)) {
-		dst_line[0] = malloc(sizeof(char) * sbpp * width);
-		dst_line[1] = malloc(sizeof(char) * sbpp * width);
-		v = 1;
-	}
-	else {
-		dst_line[0] = dest->line[0];
-		dst_line[1] = dest->line[1];
-		v = 0;
-	}
+//	if (is_video_bitmap(dest) || is_planar_bitmap(dest)) {
+//		dst_line[0] = malloc(sizeof(char) * sbpp * width);
+//		dst_line[1] = malloc(sizeof(char) * sbpp * width);
+//		v = 1;
+//	}
+//	else {
+//		dst_line[0] = dest->line[0];
+//		dst_line[1] = dest->line[1];
+//		v = 0;
+//	}
 	
 	/* Set destination */
-	bmp_select(dest);
+//	bmp_select(dest);
 
-	x = 0, y = 0;
+//	x = 0, y = 0;
 	
-    uint32_t *lbp;
-    lbp = (uint32_t*)src_line[0];
-    color[0] = *lbp;       color[1] = color[0];   color[2] = color[0];    color[3] = color[0];
-    color[4] = *(lbp + 1); color[5] = *(lbp + 2);
-    lbp = (uint32_t*)src_line[2];
-    color[6] = *lbp;     color[7] = color[6];     color[8] = *(lbp + 1); color[9] = *(lbp + 2);
-    lbp = (uint32_t*)src_line[3];
-    color[10] = *lbp;    color[11] = *(lbp + 1);
+//    uint32_t *lbp;
+//    lbp = (uint32_t*)src_line[0];
+//    color[0] = *lbp;       color[1] = color[0];   color[2] = color[0];    color[3] = color[0];
+//    color[4] = *(lbp + 1); color[5] = *(lbp + 2);
+//    lbp = (uint32_t*)src_line[2];
+//    color[6] = *lbp;     color[7] = color[6];     color[8] = *(lbp + 1); color[9] = *(lbp + 2);
+//    lbp = (uint32_t*)src_line[3];
+//    color[10] = *lbp;    color[11] = *(lbp + 1);
 
-	for (y = 0; y < height; y++) {
+//	for (y = 0; y < height; y++) {
 	
 		/* Todo: x = width - 2, x = width - 1 */
 		
-		for (x = 0; x < width; x++) {
-			uint32_t product1a, product1b, product2a, product2b;
+//		for (x = 0; x < width; x++) {
+//			uint32_t product1a, product1b, product2a, product2b;
 
 //---------------------------------------     B1 B2           0  1
 //                                         4  5  6  S2 ->  2  3  4  5
 //                                         1  2  3  S1     6  7  8  9
 //                                            A1 A2          10 11
 
-			if (color[7] == color[4] && color[3] != color[8]) {
-				product1b = product2a = color[7];
+//			if (color[7] == color[4] && color[3] != color[8]) {
+//				product1b = product2a = color[7];
 
-				if ((color[6] == color[7]) || (color[4] == color[1]))
-					product1a = INTERPOLATE(color[7], INTERPOLATE(color[7], color[3]));
-				else
-					product1a = INTERPOLATE(color[3], color[4]);
+//				if ((color[6] == color[7]) || (color[4] == color[1]))
+//					product1a = INTERPOLATE(color[7], INTERPOLATE(color[7], color[3]));
+//				else
+//					product1a = INTERPOLATE(color[3], color[4]);
 
-				if ((color[4] == color[5]) || (color[7] == color[10]))
-					product2b = INTERPOLATE(color[7], INTERPOLATE(color[7], color[8]));
-				else
-					product2b = INTERPOLATE(color[7], color[8]);
-			}
-			else if (color[3] == color[8] && color[7] != color[4]) {
-				product2b = product1a = color[3];
+//				if ((color[4] == color[5]) || (color[7] == color[10]))
+//					product2b = INTERPOLATE(color[7], INTERPOLATE(color[7], color[8]));
+//				else
+//					product2b = INTERPOLATE(color[7], color[8]);
+//			}
+//			else if (color[3] == color[8] && color[7] != color[4]) {
+//				product2b = product1a = color[3];
 
-				if ((color[0] == color[3]) || (color[5] == color[9]))
-					product1b = INTERPOLATE(color[3], INTERPOLATE(color[3], color[4]));
-				else
-					product1b = INTERPOLATE(color[3], color[1]);
+//				if ((color[0] == color[3]) || (color[5] == color[9]))
+//					product1b = INTERPOLATE(color[3], INTERPOLATE(color[3], color[4]));
+//				else
+//					product1b = INTERPOLATE(color[3], color[1]);
 
-				if ((color[8] == color[11]) || (color[2] == color[3]))
-					product2a = INTERPOLATE(color[3], INTERPOLATE(color[3], color[2]));
-				else
-					product2a = INTERPOLATE(color[7], color[8]);
+//				if ((color[8] == color[11]) || (color[2] == color[3]))
+//					product2a = INTERPOLATE(color[3], INTERPOLATE(color[3], color[2]));
+//				else
+//					product2a = INTERPOLATE(color[7], color[8]);
 
-			}
-			else if (color[3] == color[8] && color[7] == color[4]) {
-				register int r = 0;
+//			}
+//			else if (color[3] == color[8] && color[7] == color[4]) {
+//				register int r = 0;
 
-				r += GET_RESULT(color[4], color[3], color[6], color[10]);
-				r += GET_RESULT(color[4], color[3], color[2], color[0]);
-				r += GET_RESULT(color[4], color[3], color[11], color[9]);
-				r += GET_RESULT(color[4], color[3], color[1], color[5]);
+//				r += GET_RESULT(color[4], color[3], color[6], color[10]);
+//				r += GET_RESULT(color[4], color[3], color[2], color[0]);
+//				r += GET_RESULT(color[4], color[3], color[11], color[9]);
+//				r += GET_RESULT(color[4], color[3], color[1], color[5]);
 
-				if (r > 0) {
-					product1b = product2a = color[7];
-					product1a = product2b = INTERPOLATE(color[3], color[4]);
-				}
-				else if (r < 0) {
-					product2b = product1a = color[3];
-					product1b = product2a = INTERPOLATE(color[3], color[4]);
-				}
-				else {
-					product2b = product1a = color[3];
-					product1b = product2a = color[7];
-				}
-			}
-			else {
-				product2b = product1a = INTERPOLATE(color[7], color[4]);
-				product2b = Q_INTERPOLATE(color[8], color[8], color[8], product2b);
-				product1a = Q_INTERPOLATE(color[3], color[3], color[3], product1a);
+//				if (r > 0) {
+//					product1b = product2a = color[7];
+//					product1a = product2b = INTERPOLATE(color[3], color[4]);
+//				}
+//				else if (r < 0) {
+//					product2b = product1a = color[3];
+//					product1b = product2a = INTERPOLATE(color[3], color[4]);
+//				}
+//				else {
+//					product2b = product1a = color[3];
+//					product1b = product2a = color[7];
+//				}
+//			}
+//			else {
+//				product2b = product1a = INTERPOLATE(color[7], color[4]);
+//				product2b = Q_INTERPOLATE(color[8], color[8], color[8], product2b);
+//				product1a = Q_INTERPOLATE(color[3], color[3], color[3], product1a);
 
-				product2a = product1b = INTERPOLATE(color[3], color[8]);
-				product2a = Q_INTERPOLATE(color[7], color[7], color[7], product2a);
-				product1b = Q_INTERPOLATE(color[4], color[4], color[4], product1b);
-			}
+//				product2a = product1b = INTERPOLATE(color[3], color[8]);
+//				product2a = Q_INTERPOLATE(color[7], color[7], color[7], product2a);
+//				product1b = Q_INTERPOLATE(color[4], color[4], color[4], product1b);
+//			}
 
-            *((uint32_t *) (&dst_line[0][x * 8])) = product1a;
-            *((uint32_t *) (&dst_line[0][x * 8 + 4])) = product1b;
-            *((uint32_t *) (&dst_line[1][x * 8])) = product2a;
-            *((uint32_t *) (&dst_line[1][x * 8 + 4])) = product2b;
+//            *((uint32_t *) (&dst_line[0][x * 8])) = product1a;
+//            *((uint32_t *) (&dst_line[0][x * 8 + 4])) = product1b;
+//            *((uint32_t *) (&dst_line[1][x * 8])) = product2a;
+//            *((uint32_t *) (&dst_line[1][x * 8 + 4])) = product2b;
 			
 			/* Move color matrix forward */
-			color[0] = color[1]; 
-			color[2] = color[3]; color[3] = color[4]; color[4] = color[5];
-			color[6] = color[7]; color[7] = color[8]; color[8] = color[9]; 
-			color[10] = color[11];
+//			color[0] = color[1]; 
+//			color[2] = color[3]; color[3] = color[4]; color[4] = color[5];
+//			color[6] = color[7]; color[7] = color[8]; color[8] = color[9]; 
+//			color[10] = color[11];
 			
-			if (x < width - 2) {
-				x += 2;
-                color[1] = *(((uint32_t*)src_line[0]) + x);
-                if (x < width) {
-                    color[5] = *(((uint32_t*)src_line[1]) + x + 1);
-                    color[9] = *(((uint32_t*)src_line[2]) + x + 1);
-                }
-                color[11] = *(((uint32_t*)src_line[3]) + x);
-				x -= 2;
-			}
-		}
+//			if (x < width - 2) {
+//				x += 2;
+//                color[1] = *(((uint32_t*)src_line[0]) + x);
+//                if (x < width) {
+//                    color[5] = *(((uint32_t*)src_line[1]) + x + 1);
+//                    color[9] = *(((uint32_t*)src_line[2]) + x + 1);
+//                }
+//                color[11] = *(((uint32_t*)src_line[3]) + x);
+//				x -= 2;
+//			}
+//		}
 
 		/* We're done with one line, so we shift the source lines up */
-		src_line[0] = src_line[1];
-		src_line[1] = src_line[2];
-		src_line[2] = src_line[3];		
+//		src_line[0] = src_line[1];
+//		src_line[1] = src_line[2];
+//		src_line[2] = src_line[3];		
 
 		/* Read next line */
-		if (y + 3 >= height)
-			src_line[3] = src_line[2];
-		else
-			src_line[3] = src_line[2] + src_pitch;
+//		if (y + 3 >= height)
+//			src_line[3] = src_line[2];
+//		else
+//			src_line[3] = src_line[2] + src_pitch;
 			
 		/* Then shift the color matrix up */
-        uint32_t *lbp;
-        lbp = (uint32_t*)src_line[0];
-        color[0] = *lbp;     color[1] = *(lbp + 1);
-        lbp = (uint32_t*)src_line[1];
-        color[2] = *lbp;     color[3] = color[2];    color[4] = *(lbp + 1);  color[5] = *(lbp + 2);
-        lbp = (uint32_t*)src_line[2];
-        color[6] = *lbp;     color[7] = color[6];    color[8] = *(lbp + 1);  color[9] = *(lbp + 2);
-        lbp = (uint32_t*)src_line[3];
-        color[10] = *lbp;    color[11] = *(lbp + 1);
+//        uint32_t *lbp;
+//        lbp = (uint32_t*)src_line[0];
+//        color[0] = *lbp;     color[1] = *(lbp + 1);
+//        lbp = (uint32_t*)src_line[1];
+//        color[2] = *lbp;     color[3] = color[2];    color[4] = *(lbp + 1);  color[5] = *(lbp + 2);
+//        lbp = (uint32_t*)src_line[2];
+//        color[6] = *lbp;     color[7] = color[6];    color[8] = *(lbp + 1);  color[9] = *(lbp + 2);
+//        lbp = (uint32_t*)src_line[3];
+//        color[10] = *lbp;    color[11] = *(lbp + 1);
 
 		/* Write the 2 lines, if not already done so */
-		if (v) {
-			uint32_t dst_addr;
+//		if (v) {
+//			uint32_t dst_addr;
 		
-			dst_addr = bmp_write_line(dest, y * 2);
-			for (j = 0; j < dest->w * sbpp; j += sizeof(long))
-				bmp_write32(dst_addr + j, *((uint32_t *) (dst_line[0] + j)));
+//			dst_addr = bmp_write_line(dest, y * 2);
+//			for (j = 0; j < dest->w * sbpp; j += sizeof(long))
+//				bmp_write32(dst_addr + j, *((uint32_t *) (dst_line[0] + j)));
 				
-			dst_addr = bmp_write_line(dest, y * 2 + 1);
-			for (j = 0; j < dest->w * sbpp; j += sizeof(long))
-				bmp_write32(dst_addr + j, *((uint32_t *) (dst_line[1] + j)));
-		}
-		else {
-			if (y < height - 1) {
-				dst_line[0] = dest->line[y * 2 + 2];
-				dst_line[1] = dest->line[y * 2 + 3];
-			}
-		}
-	}
-	bmp_unwrite_line(dest);
+//			dst_addr = bmp_write_line(dest, y * 2 + 1);
+//			for (j = 0; j < dest->w * sbpp; j += sizeof(long))
+//				bmp_write32(dst_addr + j, *((uint32_t *) (dst_line[1] + j)));
+//		}
+//		else {
+//			if (y < height - 1) {
+//				dst_line[0] = dest->line[y * 2 + 2];
+//				dst_line[1] = dest->line[y * 2 + 3];
+//			}
+//		}
+//	}
+//	bmp_unwrite_line(dest);
 	
-	if (v) {
-		free(dst_line[0]);
-		free(dst_line[1]);
-	}
-}
+//	if (v) {
+//		free(dst_line[0]);
+//		free(dst_line[1]);
+//	}
+//}

--- a/src/host_abstraction_layer/allegro_5/2xsai.c
+++ b/src/host_abstraction_layer/allegro_5/2xsai.c
@@ -244,11 +244,6 @@ void Super2xSaI(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, u
             *((uint32_t *) (&dst_line[0][x * 8 + 4])) = product1b;
             *((uint32_t *) (&dst_line[1][x * 8])) = product2a;
             *((uint32_t *) (&dst_line[1][x * 8 + 4])) = product2b;
-			// TODO: Following does not work yet.
-			//*((uint32_t *) (&dst_line[0][x * 8]) + destRegion->pitch) = product1a;
-            //*((uint32_t *) (&dst_line[0][x * 8 + 4]) + destRegion->pitch) = product1b;
-            //*((uint32_t *) (&dst_line[1][x * 8]) + destRegion->pitch) = product2a;
-            //*((uint32_t *) (&dst_line[1][x * 8 + 4])+ destRegion->pitch) = product2b;
 			
 			/* Move color matrix forward */
 			color[0] = color[1]; color[4] = color[5]; color[8] = color[9];   color[12] = color[13];

--- a/src/host_abstraction_layer/allegro_5/2xsai.c
+++ b/src/host_abstraction_layer/allegro_5/2xsai.c
@@ -325,215 +325,216 @@ void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width
 
 
 
-//void SuperEagle(ALLEGRO_BITMAP * bitmapSource, ALLEGRO_BITMAP * bitmapDest, int s_x, int s_y, int d_x, int d_y, int w, int h)
-//{
-//	int sbpp, dbpp;
+void SuperEagle(ALLEGRO_BITMAP * bitmapSource, ALLEGRO_BITMAP * bitmapDest, int s_x, int s_y, int d_x, int d_y, int w, int h)
+{
+	int sbpp, dbpp;
 
-//	ALLEGRO_BITMAP * dst2         = NULL;
+	ALLEGRO_BITMAP * dst2         = NULL;
 
-//	if (!bitmapSource || !bitmapDest)
-//		return;
+	if (!bitmapSource || !bitmapDest)
+		return;
 
-//	sbpp = bitmap_color_depth(bitmapSource);
-//	dbpp = bitmap_color_depth(bitmapDest);
+	sbpp = bitmap_color_depth(bitmapSource);
+	dbpp = bitmap_color_depth(bitmapDest);
 
-//	if ((sbpp != xsai_depth) || (sbpp != dbpp))	/* Must be same color depth */
-//		return;
+	if ((sbpp != xsai_depth) || (sbpp != dbpp))	/* Must be same color depth */
+		return;
 		
-//	if (w < 4 || h < 4) {  /* Image is too small to be 2xSaI'ed. */
-//		stretch_blit(bitmapSource, bitmapDest, s_x, s_y, w, h, d_x, d_y, w * 2, h * 2);
-//		return;
-//	}	
+	if (w < 4 || h < 4) {  /* Image is too small to be 2xSaI'ed. */
+		stretch_blit(bitmapSource, bitmapDest, s_x, s_y, w, h, d_x, d_y, w * 2, h * 2);
+		return;
+	}	
 	
-//	sbpp = BYTES_PER_PIXEL(sbpp);
-//	if (d_x || d_y)
-//		dst2 = create_sub_bitmap(bitmapDest, d_x, d_y, w * 2, h * 2);
+	sbpp = BYTES_PER_PIXEL(sbpp);
+	if (d_x || d_y)
+		dst2 = create_sub_bitmap(bitmapDest, d_x, d_y, w * 2, h * 2);
 	
-//	SuperEagle_ex(bitmapSource->line[s_y] + s_x * sbpp, (unsigned int)(bitmapSource->line[1] - bitmapSource->line[0]), NULL, dst2 ? dst2 : bitmapDest, w, h);
+	SuperEagle_ex(bitmapSource->line[s_y] + s_x * sbpp, (unsigned int)(bitmapSource->line[1] - bitmapSource->line[0]), NULL, dst2 ? dst2 : bitmapDest, w, h);
 	
-//	if (dst2)
-//		destroy_bitmap(dst2);
+	if (dst2)
+		destroy_bitmap(dst2);
 	
-//	return;
-//}
+	return;
+}
 
-//void SuperEagle_ex(uint8 *src, uint32 src_pitch, uint8 *unused, ALLEGRO_BITMAP *dest, uint32 width, uint32 height) {
+void SuperEagle_ex(uint8 *src, uint32 src_pitch, uint8 *unused, ALLEGRO_BITMAP *dest, uint32 width, uint32 height)
+{
 
-//	int j, v;
-//	unsigned int x, y;
-//	int sbpp = BYTES_PER_PIXEL(bitmap_color_depth(dest));
-//	uint32_t color[12];
+	int j, v;
+	unsigned int x, y;
+	int sbpp = BYTES_PER_PIXEL(bitmap_color_depth(dest));
+	uint32_t color[12];
 
 	/* Point to the first 3 lines. */
-//	src_line[0] = src;
-//	src_line[1] = src;
-//	src_line[2] = src + src_pitch;
-//	src_line[3] = src + src_pitch * 2;
+	src_line[0] = src;
+	src_line[1] = src;
+	src_line[2] = src + src_pitch;
+	src_line[3] = src + src_pitch * 2;
 	
 	/* Can we write the results directly? */
-//	if (is_video_bitmap(dest) || is_planar_bitmap(dest)) {
-//		dst_line[0] = malloc(sizeof(char) * sbpp * width);
-//		dst_line[1] = malloc(sizeof(char) * sbpp * width);
-//		v = 1;
-//	}
-//	else {
-//		dst_line[0] = dest->line[0];
-//		dst_line[1] = dest->line[1];
-//		v = 0;
-//	}
+	if (is_video_bitmap(dest) || is_planar_bitmap(dest)) {
+		dst_line[0] = malloc(sizeof(char) * sbpp * width);
+		dst_line[1] = malloc(sizeof(char) * sbpp * width);
+		v = 1;
+	}
+	else {
+		dst_line[0] = dest->line[0];
+		dst_line[1] = dest->line[1];
+		v = 0;
+	}
 	
 	/* Set destination */
-//	bmp_select(dest);
+	bmp_select(dest);
 
-//	x = 0, y = 0;
+	x = 0, y = 0;
 	
-//    uint32_t *lbp;
-//    lbp = (uint32_t*)src_line[0];
-//    color[0] = *lbp;       color[1] = color[0];   color[2] = color[0];    color[3] = color[0];
-//    color[4] = *(lbp + 1); color[5] = *(lbp + 2);
-//    lbp = (uint32_t*)src_line[2];
-//    color[6] = *lbp;     color[7] = color[6];     color[8] = *(lbp + 1); color[9] = *(lbp + 2);
-//    lbp = (uint32_t*)src_line[3];
-//    color[10] = *lbp;    color[11] = *(lbp + 1);
+    uint32_t *lbp;
+    lbp = (uint32_t*)src_line[0];
+    color[0] = *lbp;       color[1] = color[0];   color[2] = color[0];    color[3] = color[0];
+    color[4] = *(lbp + 1); color[5] = *(lbp + 2);
+    lbp = (uint32_t*)src_line[2];
+    color[6] = *lbp;     color[7] = color[6];     color[8] = *(lbp + 1); color[9] = *(lbp + 2);
+    lbp = (uint32_t*)src_line[3];
+    color[10] = *lbp;    color[11] = *(lbp + 1);
 
-//	for (y = 0; y < height; y++) {
+	for (y = 0; y < height; y++) {
 	
 		/* Todo: x = width - 2, x = width - 1 */
 		
-//		for (x = 0; x < width; x++) {
-//			uint32_t product1a, product1b, product2a, product2b;
+		for (x = 0; x < width; x++) {
+			uint32_t product1a, product1b, product2a, product2b;
 
 //---------------------------------------     B1 B2           0  1
 //                                         4  5  6  S2 ->  2  3  4  5
 //                                         1  2  3  S1     6  7  8  9
 //                                            A1 A2          10 11
 
-//			if (color[7] == color[4] && color[3] != color[8]) {
-//				product1b = product2a = color[7];
+			if (color[7] == color[4] && color[3] != color[8]) {
+				product1b = product2a = color[7];
 
-//				if ((color[6] == color[7]) || (color[4] == color[1]))
-//					product1a = INTERPOLATE(color[7], INTERPOLATE(color[7], color[3]));
-//				else
-//					product1a = INTERPOLATE(color[3], color[4]);
+				if ((color[6] == color[7]) || (color[4] == color[1]))
+					product1a = INTERPOLATE(color[7], INTERPOLATE(color[7], color[3]));
+				else
+					product1a = INTERPOLATE(color[3], color[4]);
 
-//				if ((color[4] == color[5]) || (color[7] == color[10]))
-//					product2b = INTERPOLATE(color[7], INTERPOLATE(color[7], color[8]));
-//				else
-//					product2b = INTERPOLATE(color[7], color[8]);
-//			}
-//			else if (color[3] == color[8] && color[7] != color[4]) {
-//				product2b = product1a = color[3];
+				if ((color[4] == color[5]) || (color[7] == color[10]))
+					product2b = INTERPOLATE(color[7], INTERPOLATE(color[7], color[8]));
+				else
+					product2b = INTERPOLATE(color[7], color[8]);
+			}
+			else if (color[3] == color[8] && color[7] != color[4]) {
+				product2b = product1a = color[3];
 
-//				if ((color[0] == color[3]) || (color[5] == color[9]))
-//					product1b = INTERPOLATE(color[3], INTERPOLATE(color[3], color[4]));
-//				else
-//					product1b = INTERPOLATE(color[3], color[1]);
+				if ((color[0] == color[3]) || (color[5] == color[9]))
+					product1b = INTERPOLATE(color[3], INTERPOLATE(color[3], color[4]));
+				else
+					product1b = INTERPOLATE(color[3], color[1]);
 
-//				if ((color[8] == color[11]) || (color[2] == color[3]))
-//					product2a = INTERPOLATE(color[3], INTERPOLATE(color[3], color[2]));
-//				else
-//					product2a = INTERPOLATE(color[7], color[8]);
+				if ((color[8] == color[11]) || (color[2] == color[3]))
+					product2a = INTERPOLATE(color[3], INTERPOLATE(color[3], color[2]));
+				else
+					product2a = INTERPOLATE(color[7], color[8]);
 
-//			}
-//			else if (color[3] == color[8] && color[7] == color[4]) {
-//				register int r = 0;
+			}
+			else if (color[3] == color[8] && color[7] == color[4]) {
+				register int r = 0;
 
-//				r += GET_RESULT(color[4], color[3], color[6], color[10]);
-//				r += GET_RESULT(color[4], color[3], color[2], color[0]);
-//				r += GET_RESULT(color[4], color[3], color[11], color[9]);
-//				r += GET_RESULT(color[4], color[3], color[1], color[5]);
+				r += GET_RESULT(color[4], color[3], color[6], color[10]);
+				r += GET_RESULT(color[4], color[3], color[2], color[0]);
+				r += GET_RESULT(color[4], color[3], color[11], color[9]);
+				r += GET_RESULT(color[4], color[3], color[1], color[5]);
 
-//				if (r > 0) {
-//					product1b = product2a = color[7];
-//					product1a = product2b = INTERPOLATE(color[3], color[4]);
-//				}
-//				else if (r < 0) {
-//					product2b = product1a = color[3];
-//					product1b = product2a = INTERPOLATE(color[3], color[4]);
-//				}
-//				else {
-//					product2b = product1a = color[3];
-//					product1b = product2a = color[7];
-//				}
-//			}
-//			else {
-//				product2b = product1a = INTERPOLATE(color[7], color[4]);
-//				product2b = Q_INTERPOLATE(color[8], color[8], color[8], product2b);
-//				product1a = Q_INTERPOLATE(color[3], color[3], color[3], product1a);
+				if (r > 0) {
+					product1b = product2a = color[7];
+					product1a = product2b = INTERPOLATE(color[3], color[4]);
+				}
+				else if (r < 0) {
+					product2b = product1a = color[3];
+					product1b = product2a = INTERPOLATE(color[3], color[4]);
+				}
+				else {
+					product2b = product1a = color[3];
+					product1b = product2a = color[7];
+				}
+			}
+			else {
+				product2b = product1a = INTERPOLATE(color[7], color[4]);
+				product2b = Q_INTERPOLATE(color[8], color[8], color[8], product2b);
+				product1a = Q_INTERPOLATE(color[3], color[3], color[3], product1a);
 
-//				product2a = product1b = INTERPOLATE(color[3], color[8]);
-//				product2a = Q_INTERPOLATE(color[7], color[7], color[7], product2a);
-//				product1b = Q_INTERPOLATE(color[4], color[4], color[4], product1b);
-//			}
+				product2a = product1b = INTERPOLATE(color[3], color[8]);
+				product2a = Q_INTERPOLATE(color[7], color[7], color[7], product2a);
+				product1b = Q_INTERPOLATE(color[4], color[4], color[4], product1b);
+			}
 
-//            *((uint32_t *) (&dst_line[0][x * 8])) = product1a;
-//            *((uint32_t *) (&dst_line[0][x * 8 + 4])) = product1b;
-//            *((uint32_t *) (&dst_line[1][x * 8])) = product2a;
-//            *((uint32_t *) (&dst_line[1][x * 8 + 4])) = product2b;
+            *((uint32_t *) (&dst_line[0][x * 8])) = product1a;
+            *((uint32_t *) (&dst_line[0][x * 8 + 4])) = product1b;
+            *((uint32_t *) (&dst_line[1][x * 8])) = product2a;
+            *((uint32_t *) (&dst_line[1][x * 8 + 4])) = product2b;
 			
 			/* Move color matrix forward */
-//			color[0] = color[1]; 
-//			color[2] = color[3]; color[3] = color[4]; color[4] = color[5];
-//			color[6] = color[7]; color[7] = color[8]; color[8] = color[9]; 
-//			color[10] = color[11];
+			color[0] = color[1]; 
+			color[2] = color[3]; color[3] = color[4]; color[4] = color[5];
+			color[6] = color[7]; color[7] = color[8]; color[8] = color[9]; 
+			color[10] = color[11];
 			
-//			if (x < width - 2) {
-//				x += 2;
-//                color[1] = *(((uint32_t*)src_line[0]) + x);
-//                if (x < width) {
-//                    color[5] = *(((uint32_t*)src_line[1]) + x + 1);
-//                    color[9] = *(((uint32_t*)src_line[2]) + x + 1);
-//                }
-//                color[11] = *(((uint32_t*)src_line[3]) + x);
-//				x -= 2;
-//			}
-//		}
+			if (x < width - 2) {
+				x += 2;
+                color[1] = *(((uint32_t*)src_line[0]) + x);
+                if (x < width) {
+                    color[5] = *(((uint32_t*)src_line[1]) + x + 1);
+                    color[9] = *(((uint32_t*)src_line[2]) + x + 1);
+                }
+                color[11] = *(((uint32_t*)src_line[3]) + x);
+				x -= 2;
+			}
+		}
 
 		/* We're done with one line, so we shift the source lines up */
-//		src_line[0] = src_line[1];
-//		src_line[1] = src_line[2];
-//		src_line[2] = src_line[3];		
+		src_line[0] = src_line[1];
+		src_line[1] = src_line[2];
+		src_line[2] = src_line[3];		
 
 		/* Read next line */
-//		if (y + 3 >= height)
-//			src_line[3] = src_line[2];
-//		else
-//			src_line[3] = src_line[2] + src_pitch;
+		if (y + 3 >= height)
+			src_line[3] = src_line[2];
+		else
+			src_line[3] = src_line[2] + src_pitch;
 			
 		/* Then shift the color matrix up */
-//        uint32_t *lbp;
-//        lbp = (uint32_t*)src_line[0];
-//        color[0] = *lbp;     color[1] = *(lbp + 1);
-//        lbp = (uint32_t*)src_line[1];
-//        color[2] = *lbp;     color[3] = color[2];    color[4] = *(lbp + 1);  color[5] = *(lbp + 2);
-//        lbp = (uint32_t*)src_line[2];
-//        color[6] = *lbp;     color[7] = color[6];    color[8] = *(lbp + 1);  color[9] = *(lbp + 2);
-//        lbp = (uint32_t*)src_line[3];
-//        color[10] = *lbp;    color[11] = *(lbp + 1);
+        uint32_t *lbp;
+        lbp = (uint32_t*)src_line[0];
+        color[0] = *lbp;     color[1] = *(lbp + 1);
+        lbp = (uint32_t*)src_line[1];
+        color[2] = *lbp;     color[3] = color[2];    color[4] = *(lbp + 1);  color[5] = *(lbp + 2);
+        lbp = (uint32_t*)src_line[2];
+        color[6] = *lbp;     color[7] = color[6];    color[8] = *(lbp + 1);  color[9] = *(lbp + 2);
+        lbp = (uint32_t*)src_line[3];
+        color[10] = *lbp;    color[11] = *(lbp + 1);
 
 		/* Write the 2 lines, if not already done so */
-//		if (v) {
-//			uint32_t dst_addr;
+		if (v) {
+			uint32_t dst_addr;
 		
-//			dst_addr = bmp_write_line(dest, y * 2);
-//			for (j = 0; j < dest->w * sbpp; j += sizeof(long))
-//				bmp_write32(dst_addr + j, *((uint32_t *) (dst_line[0] + j)));
+			dst_addr = bmp_write_line(dest, y * 2);
+			for (j = 0; j < dest->w * sbpp; j += sizeof(long))
+				bmp_write32(dst_addr + j, *((uint32_t *) (dst_line[0] + j)));
 				
-//			dst_addr = bmp_write_line(dest, y * 2 + 1);
-//			for (j = 0; j < dest->w * sbpp; j += sizeof(long))
-//				bmp_write32(dst_addr + j, *((uint32_t *) (dst_line[1] + j)));
-//		}
-//		else {
-//			if (y < height - 1) {
-//				dst_line[0] = dest->line[y * 2 + 2];
-//				dst_line[1] = dest->line[y * 2 + 3];
-//			}
-//		}
-//	}
-//	bmp_unwrite_line(dest);
+			dst_addr = bmp_write_line(dest, y * 2 + 1);
+			for (j = 0; j < dest->w * sbpp; j += sizeof(long))
+				bmp_write32(dst_addr + j, *((uint32_t *) (dst_line[1] + j)));
+		}
+		else {
+			if (y < height - 1) {
+				dst_line[0] = dest->line[y * 2 + 2];
+				dst_line[1] = dest->line[y * 2 + 3];
+			}
+		}
+	}
+	bmp_unwrite_line(dest);
 	
-//	if (v) {
-//		free(dst_line[0]);
-//		free(dst_line[1]);
-//	}
-//}
+	if (v) {
+		free(dst_line[0]);
+		free(dst_line[1]);
+	}
+}

--- a/src/host_abstraction_layer/allegro_5/2xsai.c
+++ b/src/host_abstraction_layer/allegro_5/2xsai.c
@@ -325,77 +325,55 @@ void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width
 
 
 
-void SuperEagle(ALLEGRO_BITMAP * bitmapSource, ALLEGRO_BITMAP * bitmapDest, int s_x, int s_y, int d_x, int d_y, int w, int h)
+void SuperEagle(uint8_t * elk_screen_data, ALLEGRO_BITMAP * bitmapDest, int w, int h)
 {
-	int sbpp, dbpp;
-
-	ALLEGRO_BITMAP * dst2         = NULL;
-
-	if (!bitmapSource || !bitmapDest)
-		return;
-
-	sbpp = bitmap_color_depth(bitmapSource);
-	dbpp = bitmap_color_depth(bitmapDest);
-
-	if ((sbpp != xsai_depth) || (sbpp != dbpp))	/* Must be same color depth */
-		return;
-		
-	if (w < 4 || h < 4) {  /* Image is too small to be 2xSaI'ed. */
-		stretch_blit(bitmapSource, bitmapDest, s_x, s_y, w, h, d_x, d_y, w * 2, h * 2);
-		return;
-	}	
-	
-	sbpp = BYTES_PER_PIXEL(sbpp);
-	if (d_x || d_y)
-		dst2 = create_sub_bitmap(bitmapDest, d_x, d_y, w * 2, h * 2);
-	
-	SuperEagle_ex(bitmapSource->line[s_y] + s_x * sbpp, (unsigned int)(bitmapSource->line[1] - bitmapSource->line[0]), NULL, dst2 ? dst2 : bitmapDest, w, h);
-	
-	if (dst2)
-		destroy_bitmap(dst2);
-	
-	return;
+	SuperEagle_ex(elk_screen_data, bitmapDest, w, h);
 }
 
-void SuperEagle_ex(uint8 *src, uint32 src_pitch, uint8 *unused, ALLEGRO_BITMAP *dest, uint32 width, uint32 height)
+void SuperEagle_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, uint32 height)
 {
 
 	int j, v;
 	unsigned int x, y;
-	int sbpp = BYTES_PER_PIXEL(bitmap_color_depth(dest));
 	uint32_t color[12];
 
 	/* Point to the first 3 lines. */
-	src_line[0] = src;
-	src_line[1] = src;
-	src_line[2] = src + src_pitch;
-	src_line[3] = src + src_pitch * 2;
+	src_line[0] = elk_screen_data;
+	src_line[1] = elk_screen_data;
+	src_line[2] = elk_screen_data + width;
+	src_line[3] = elk_screen_data + (width * 2);
 	
+    uint8_t * region_data_line = NULL;
+	ALLEGRO_LOCKED_REGION * destRegion = al_lock_bitmap(dest, ALLEGRO_PIXEL_FORMAT_ARGB_8888, ALLEGRO_LOCK_WRITEONLY);
+    region_data_line = (uint8_t *)destRegion->data;
+
 	/* Can we write the results directly? */
-	if (is_video_bitmap(dest) || is_planar_bitmap(dest)) {
-		dst_line[0] = malloc(sizeof(char) * sbpp * width);
-		dst_line[1] = malloc(sizeof(char) * sbpp * width);
-		v = 1;
-	}
-	else {
-		dst_line[0] = dest->line[0];
-		dst_line[1] = dest->line[1];
-		v = 0;
-	}
-	
-	/* Set destination */
-	bmp_select(dest);
+	dst_line[0] = region_data_line;
+	dst_line[1] = region_data_line + destRegion->pitch;
 
 	x = 0, y = 0;
 	
-    uint32_t *lbp;
-    lbp = (uint32_t*)src_line[0];
-    color[0] = *lbp;       color[1] = color[0];   color[2] = color[0];    color[3] = color[0];
-    color[4] = *(lbp + 1); color[5] = *(lbp + 2);
-    lbp = (uint32_t*)src_line[2];
-    color[6] = *lbp;     color[7] = color[6];     color[8] = *(lbp + 1); color[9] = *(lbp + 2);
-    lbp = (uint32_t*)src_line[3];
-    color[10] = *lbp;    color[11] = *(lbp + 1);
+    // uint32_t *lbp;
+    uint32_t lbp, lbp1, lbp2;
+
+    lbp  = elkpal[*src_line[0]];
+	lbp1 = elkpal[*(src_line[0] + 1)];
+	lbp2 = elkpal[*(src_line[0] + 2)];
+
+    color[0] = lbp;       color[1] = color[0];   color[2] = color[0];    color[3] = color[0];
+    color[4] = lbp1;      color[5] = lbp2;
+
+    lbp  = elkpal[*src_line[2]];
+	lbp1 = elkpal[*(src_line[2] + 1)];
+	lbp2 = elkpal[*(src_line[2] + 2)];
+
+    color[6] = lbp;     color[7] = color[6];     color[8] = lbp1; color[9] = lbp2;
+
+    lbp  = elkpal[*src_line[3]];
+	lbp1 = elkpal[*(src_line[3] + 1)];
+	lbp2 = elkpal[*(src_line[3] + 2)];
+
+    color[10] = lbp;    color[11] = lbp1;
 
 	for (y = 0; y < height; y++) {
 	
@@ -499,42 +477,40 @@ void SuperEagle_ex(uint8 *src, uint32 src_pitch, uint8 *unused, ALLEGRO_BITMAP *
 		if (y + 3 >= height)
 			src_line[3] = src_line[2];
 		else
-			src_line[3] = src_line[2] + src_pitch;
+			src_line[3] = src_line[2] + width;
 			
 		/* Then shift the color matrix up */
-        uint32_t *lbp;
-        lbp = (uint32_t*)src_line[0];
-        color[0] = *lbp;     color[1] = *(lbp + 1);
-        lbp = (uint32_t*)src_line[1];
-        color[2] = *lbp;     color[3] = color[2];    color[4] = *(lbp + 1);  color[5] = *(lbp + 2);
-        lbp = (uint32_t*)src_line[2];
-        color[6] = *lbp;     color[7] = color[6];    color[8] = *(lbp + 1);  color[9] = *(lbp + 2);
-        lbp = (uint32_t*)src_line[3];
-        color[10] = *lbp;    color[11] = *(lbp + 1);
+        lbp  = elkpal[*src_line[0]];
+	    lbp1 = elkpal[*(src_line[0] + 1)];
+    	lbp2 = elkpal[*(src_line[0] + 2)];
+
+        color[0] = lbp;     color[1] = lbp1;
+
+        lbp  = elkpal[*src_line[1]];
+	    lbp1 = elkpal[*(src_line[1] + 1)];
+    	lbp2 = elkpal[*(src_line[1] + 2)];
+
+        color[2] = lbp;     color[3] = color[2];    color[4] = lbp1;  color[5] = lbp2;
+
+        lbp  = elkpal[*src_line[2]];
+	    lbp1 = elkpal[*(src_line[2] + 1)];
+    	lbp2 = elkpal[*(src_line[2] + 2)];
+
+        color[6] = lbp;     color[7] = color[6];    color[8] = lbp1;  color[9] = lbp2;
+
+        lbp  = elkpal[*src_line[3]];
+	    lbp1 = elkpal[*(src_line[3] + 1)];
+    	lbp2 = elkpal[*(src_line[3] + 2)];
+
+        color[10] = lbp;    color[11] = lbp1;
 
 		/* Write the 2 lines, if not already done so */
-		if (v) {
-			uint32_t dst_addr;
-		
-			dst_addr = bmp_write_line(dest, y * 2);
-			for (j = 0; j < dest->w * sbpp; j += sizeof(long))
-				bmp_write32(dst_addr + j, *((uint32_t *) (dst_line[0] + j)));
-				
-			dst_addr = bmp_write_line(dest, y * 2 + 1);
-			for (j = 0; j < dest->w * sbpp; j += sizeof(long))
-				bmp_write32(dst_addr + j, *((uint32_t *) (dst_line[1] + j)));
+        if (y < height - 1) {
+            int dest_pitch_y_plus_2 = (destRegion->pitch * ((y * 2 + 2)));
+			int dest_pitch_y_plus_3 = (destRegion->pitch * ((y * 2 + 3)));
+
+			dst_line[0] = region_data_line + dest_pitch_y_plus_2;
+			dst_line[1] = region_data_line + dest_pitch_y_plus_3;
 		}
-		else {
-			if (y < height - 1) {
-				dst_line[0] = dest->line[y * 2 + 2];
-				dst_line[1] = dest->line[y * 2 + 3];
-			}
-		}
-	}
-	bmp_unwrite_line(dest);
-	
-	if (v) {
-		free(dst_line[0]);
-		free(dst_line[1]);
 	}
 }

--- a/src/host_abstraction_layer/allegro_5/2xsai.c
+++ b/src/host_abstraction_layer/allegro_5/2xsai.c
@@ -312,8 +312,8 @@ void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width
 		/* Write the 2 lines, if not already done so */
 		if (y < height - 1) {
 
-			int dest_pitch_y_plus_2 = (destRegion->pitch * ((y + 2)));
-			int dest_pitch_y_plus_3 = (destRegion->pitch * ((y + 3)));
+			int dest_pitch_y_plus_2 = (destRegion->pitch * ((y * 2 + 2)));
+			int dest_pitch_y_plus_3 = (destRegion->pitch * ((y * 2 + 3)));
 
 			dst_line[0] = region_data_line + dest_pitch_y_plus_2;
 			dst_line[1] = region_data_line + dest_pitch_y_plus_3;

--- a/src/host_abstraction_layer/allegro_5/2xsai.c
+++ b/src/host_abstraction_layer/allegro_5/2xsai.c
@@ -152,8 +152,8 @@ void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width
     region_data_line = (uint8_t *)destRegion->data;
 
 	/* Can we write the results directly? */
-	dst_line[0] = (uint8 *)region_data_line;
-	dst_line[1] = (uint8 *)region_data_line + destRegion->pitch;
+	dst_line[0] = region_data_line;
+	dst_line[1] = region_data_line + (destRegion->pitch * 2);
 
 	x = 0, y = 0;
 	
@@ -245,11 +245,16 @@ void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width
 				product1a = INTERPOLATE(color[9], color[5]);
 			else
 				product1a = color[5];
-	
+
             *((uint32_t *) (&dst_line[0][x * 8])) = product1a;
             *((uint32_t *) (&dst_line[0][x * 8 + 4])) = product1b;
             *((uint32_t *) (&dst_line[1][x * 8])) = product2a;
             *((uint32_t *) (&dst_line[1][x * 8 + 4])) = product2b;
+			// TODO: Following does not work yet.
+			*((uint32_t *) (&dst_line[0][x * 8]) + destRegion->pitch) = product1a;
+            *((uint32_t *) (&dst_line[0][x * 8 + 4]) + destRegion->pitch) = product1b;
+            *((uint32_t *) (&dst_line[1][x * 8]) + destRegion->pitch) = product2a;
+            *((uint32_t *) (&dst_line[1][x * 8 + 4])+ destRegion->pitch) = product2b;
 			
 			/* Move color matrix forward */
 			color[0] = color[1]; color[4] = color[5]; color[8] = color[9];   color[12] = color[13];
@@ -306,8 +311,13 @@ void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width
 		
 		/* Write the 2 lines, if not already done so */
 		if (y < height - 1) {
-			dst_line[0] = region_data_line + (destRegion->pitch * (y + 2));
-			dst_line[1] = region_data_line + (destRegion->pitch * (y + 3));
+
+			int dest_pitch_y_plus_2 = (destRegion->pitch * ((y + 2) *2));
+			int dest_pitch_y_plus_3 = (destRegion->pitch * ((y + 3) *2));
+
+			dst_line[0] = region_data_line + dest_pitch_y_plus_2;
+			dst_line[1] = region_data_line + dest_pitch_y_plus_3;
+
 		}
 	}
 	al_unlock_bitmap(dest);

--- a/src/host_abstraction_layer/allegro_5/2xsai.c
+++ b/src/host_abstraction_layer/allegro_5/2xsai.c
@@ -337,7 +337,6 @@ void SuperEagle(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, u
 
 	x = 0, y = 0;
 	
-    // uint32_t *lbp;
     uint32_t lbp, lbp1, lbp2;
 
     lbp  = elkpal[*src_line[0]];
@@ -348,14 +347,14 @@ void SuperEagle(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, u
     color[4] = lbp1;      color[5] = lbp2;
 
     lbp  = elkpal[*src_line[2]];
-	lbp1 = elkpal[*(src_line[2] + 1)];
-	lbp2 = elkpal[*(src_line[2] + 2)];
+    lbp1 = elkpal[*(src_line[2] + 1)];
+    lbp2 = elkpal[*(src_line[2] + 2)];
 
     color[6] = lbp;     color[7] = color[6];     color[8] = lbp1; color[9] = lbp2;
 
     lbp  = elkpal[*src_line[3]];
-	lbp1 = elkpal[*(src_line[3] + 1)];
-	lbp2 = elkpal[*(src_line[3] + 2)];
+    lbp1 = elkpal[*(src_line[3] + 1)];
+    lbp2 = elkpal[*(src_line[3] + 2)];
 
     color[10] = lbp;    color[11] = lbp1;
 
@@ -430,11 +429,10 @@ void SuperEagle(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, u
 			}
 
             *((uint32_t *) (&dst_line[0][x * 8])) = product1a;
-            *((uint32_t *) (&dst_line[0][(x * 8) + 4])) = product1b;
+            *((uint32_t *) (&dst_line[0][x * 8 + 4])) = product1b;
             *((uint32_t *) (&dst_line[1][x * 8])) = product2a;
-            *((uint32_t *) (&dst_line[1][(x * 8) + 4])) = product2b;
-			
-            *((uint32_t *) (&dst_line[0][x * 8])) = elkpal[*(src_line[0]+x)];
+            *((uint32_t *) (&dst_line[1][x * 8 + 4])) = product2b;
+
 			color[0] = color[1]; 
 			color[2] = color[3]; color[3] = color[4]; color[4] = color[5];
 			color[6] = color[7]; color[7] = color[8]; color[8] = color[9]; 
@@ -466,25 +464,25 @@ void SuperEagle(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, u
 		/* Then shift the color matrix up */
         lbp  = elkpal[*src_line[0]];
 	    lbp1 = elkpal[*(src_line[0] + 1)];
-    	lbp2 = elkpal[*(src_line[0] + 2)];
+        lbp2 = elkpal[*(src_line[0] + 2)];
 
         color[0] = lbp;     color[1] = lbp1;
 
         lbp  = elkpal[*src_line[1]];
 	    lbp1 = elkpal[*(src_line[1] + 1)];
-    	lbp2 = elkpal[*(src_line[1] + 2)];
+        lbp2 = elkpal[*(src_line[1] + 2)];
 
         color[2] = lbp;     color[3] = color[2];    color[4] = lbp1;  color[5] = lbp2;
 
         lbp  = elkpal[*src_line[2]];
 	    lbp1 = elkpal[*(src_line[2] + 1)];
-    	lbp2 = elkpal[*(src_line[2] + 2)];
+        lbp2 = elkpal[*(src_line[2] + 2)];
 
         color[6] = lbp;     color[7] = color[6];    color[8] = lbp1;  color[9] = lbp2;
 
         lbp  = elkpal[*src_line[3]];
 	    lbp1 = elkpal[*(src_line[3] + 1)];
-    	lbp2 = elkpal[*(src_line[3] + 2)];
+        lbp2 = elkpal[*(src_line[3] + 2)];
 
         color[10] = lbp;    color[11] = lbp1;
 

--- a/src/host_abstraction_layer/allegro_5/2xsai.c
+++ b/src/host_abstraction_layer/allegro_5/2xsai.c
@@ -153,7 +153,7 @@ void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width
 
 	/* Can we write the results directly? */
 	dst_line[0] = region_data_line;
-	dst_line[1] = region_data_line + (destRegion->pitch * 2);
+	dst_line[1] = region_data_line + destRegion->pitch;
 
 	x = 0, y = 0;
 	
@@ -312,8 +312,8 @@ void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width
 		/* Write the 2 lines, if not already done so */
 		if (y < height - 1) {
 
-			int dest_pitch_y_plus_2 = (destRegion->pitch * ((y + 2) *2));
-			int dest_pitch_y_plus_3 = (destRegion->pitch * ((y + 3) *2));
+			int dest_pitch_y_plus_2 = (destRegion->pitch * ((y + 2)));
+			int dest_pitch_y_plus_3 = (destRegion->pitch * ((y + 3)));
 
 			dst_line[0] = region_data_line + dest_pitch_y_plus_2;
 			dst_line[1] = region_data_line + dest_pitch_y_plus_3;

--- a/src/host_abstraction_layer/allegro_5/menu_settings.c
+++ b/src/host_abstraction_layer/allegro_5/menu_settings.c
@@ -52,9 +52,9 @@ elk_event_t menu_redefine_keyboard(ALLEGRO_EVENT * event);
 #define VIDEO_DISPLAY_TYPE_MAX   7
 static const char *settings_video_display_type[VIDEO_DISPLAY_TYPE_MAX] = { "Scanlines",
                                                      "Line doubling",
-                                                     "2xSai (disabled)",
+                                                     "2xSai",
                                                      "Scale2X",
-                                                     "Super Eagle (disabled)",
+                                                     "Super Eagle",
                                                      "PAL Filter", NULL };
 
 #define DISC_DRIVE_TYPE_MAX  3

--- a/src/host_abstraction_layer/allegro_5/video.c
+++ b/src/host_abstraction_layer/allegro_5/video.c
@@ -469,19 +469,29 @@ void video_blit_to_screen(int drawMode, uint8_t * elk_screen_data)
             break;
 
         case _2XSAI:  // TODO: Get filter working for allegro5
-            blit_normal(b, elk_screen_data);
+            //blit_normal(b, elk_screen_data);
+            //if(elkConfig.stats.blitting_performance_stats)
+            //{
+            //    native_time_add_sample(&video_blit_average, native_timestamp_get() - timestamp);
+            //    timestamp = native_timestamp_get();
+            //}
+
+            //al_set_target_backbuffer(al_get_current_display());
+            //al_draw_scaled_bitmap(b, 0,0,640,256, 
+            //                         current_elk_window.startx, current_elk_window.starty,
+            //                         current_elk_window.winsizex,current_elk_window.winsizey, 0);
+            //blit(b,b162,0,0,0,0,640,256);
+            Super2xSaI(elk_screen_data,b16,640,256);
             if(elkConfig.stats.blitting_performance_stats)
             {
                 native_time_add_sample(&video_blit_average, native_timestamp_get() - timestamp);
                 timestamp = native_timestamp_get();
             }
-
             al_set_target_backbuffer(al_get_current_display());
-            al_draw_scaled_bitmap(b, 0,0,640,256, 
+            al_draw_scaled_bitmap(b16, 0,0,1280,512, 
                                      current_elk_window.startx, current_elk_window.starty,
                                      current_elk_window.winsizex,current_elk_window.winsizey, 0);
-            //blit(b,b162,0,0,0,0,640,256);
-            //Super2xSaI(elk_screen_data,b,0,0,0,0,640,256);
+
             //al_set_target_backbuffer(al_get_current_display());
             //al_draw_scaled_bitmap(b16, firstx, firsty, xsize, ysize, scr_x_start, scr_y_start, scr_x_size, scr_y_size, 0);
             //al_draw_bitmap(b16, (winsizeX-640)/2,(winsizeY-512)/2);

--- a/src/host_abstraction_layer/allegro_5/video.c
+++ b/src/host_abstraction_layer/allegro_5/video.c
@@ -507,14 +507,14 @@ void video_blit_to_screen(int drawMode, uint8_t * elk_screen_data)
             break;
 
         case EAGLE: // TODO: Get filter working for allegro5
-            blit_normal(b, elk_screen_data);
+            SuperEagle(elk_screen_data,b16,640,256);
             if(elkConfig.stats.blitting_performance_stats)
             {
                 native_time_add_sample(&video_blit_average, native_timestamp_get() - timestamp);
                 timestamp = native_timestamp_get();
             }
             al_set_target_backbuffer(al_get_current_display());
-            al_draw_scaled_bitmap(b, 0,0,640,256, 
+            al_draw_scaled_bitmap(b16, 0,0,1280,512, 
                                      current_elk_window.startx, current_elk_window.starty,
                                      current_elk_window.winsizex,current_elk_window.winsizey, 0);
             //blit(b,b162,0,0,0,0,640,256);

--- a/src/host_abstraction_layer/allegro_5/video.c
+++ b/src/host_abstraction_layer/allegro_5/video.c
@@ -488,7 +488,7 @@ void video_blit_to_screen(int drawMode, uint8_t * elk_screen_data)
                 timestamp = native_timestamp_get();
             }
             al_set_target_backbuffer(al_get_current_display());
-            al_draw_scaled_bitmap(b16, 0,0,1280,512, 
+            al_draw_scaled_bitmap(b16, 0,0,1280,256, 
                                      current_elk_window.startx, current_elk_window.starty,
                                      current_elk_window.winsizex,current_elk_window.winsizey, 0);
 

--- a/src/host_abstraction_layer/allegro_5/video.c
+++ b/src/host_abstraction_layer/allegro_5/video.c
@@ -488,14 +488,9 @@ void video_blit_to_screen(int drawMode, uint8_t * elk_screen_data)
                 timestamp = native_timestamp_get();
             }
             al_set_target_backbuffer(al_get_current_display());
-            al_draw_scaled_bitmap(b16, 0,0,1280,256, 
+            al_draw_scaled_bitmap(b16, 0,0,1280,512, 
                                      current_elk_window.startx, current_elk_window.starty,
                                      current_elk_window.winsizex,current_elk_window.winsizey, 0);
-
-            //al_set_target_backbuffer(al_get_current_display());
-            //al_draw_scaled_bitmap(b16, firstx, firsty, xsize, ysize, scr_x_start, scr_y_start, scr_x_size, scr_y_size, 0);
-            //al_draw_bitmap(b16, (winsizeX-640)/2,(winsizeY-512)/2);
-            //blit(b16,screen,0,0,(winsizeX-640)/2,(winsizeY-512)/2,640,512);
             break;
 
         case SCALE2X:

--- a/src/host_abstraction_layer/allegro_5/video.c
+++ b/src/host_abstraction_layer/allegro_5/video.c
@@ -238,6 +238,7 @@ void video_init_complete()
     video_set_window_size(elkConfig.display.native_window_width, elkConfig.display.native_window_height,0,0);
     //video_set_window_size(640,512,0,0);
     //video_set_gfx_mode_windowed();
+    Init_2xSaI(32);
     initpaltables();
 }
 

--- a/src/host_abstraction_layer/allegro_5/video.c
+++ b/src/host_abstraction_layer/allegro_5/video.c
@@ -355,24 +355,6 @@ void video_leavefullscreen()
     }
 }
 
-//#ifdef WIN32
-//CRITICAL_SECTION cs;
-//#endif
-
-void startblit()
-{
-//    #ifdef WIN32
-//        EnterCriticalSection(&cs);
-//    #endif
-}
-
-void endblit()
-{
-//    #ifdef WIN32
-//        LeaveCriticalSection(&cs);
-//    #endif
-}
-
 void blit_normal(ALLEGRO_BITMAP * destBitmap, uint8_t * elk_screen_data)
 {
     int y = 0;
@@ -438,8 +420,6 @@ void video_blit_to_screen(int drawMode, uint8_t * elk_screen_data)
     ALLEGRO_COLOR bordercol = al_map_rgb(elkConfig.display.border.red, elkConfig.display.border.green, elkConfig.display.border.blue); // TODO: Optimise this (store, don't recalculate every blit).
     al_draw_filled_rectangle(0,0, al_get_display_width(display), al_get_display_height(display), bordercol);
 
-    startblit();
-
     switch (drawMode)
     {
         case SCANLINES:
@@ -468,19 +448,7 @@ void video_blit_to_screen(int drawMode, uint8_t * elk_screen_data)
                                      current_elk_window.winsizex,current_elk_window.winsizey, 0);
             break;
 
-        case _2XSAI:  // TODO: Get filter working for allegro5
-            //blit_normal(b, elk_screen_data);
-            //if(elkConfig.stats.blitting_performance_stats)
-            //{
-            //    native_time_add_sample(&video_blit_average, native_timestamp_get() - timestamp);
-            //    timestamp = native_timestamp_get();
-            //}
-
-            //al_set_target_backbuffer(al_get_current_display());
-            //al_draw_scaled_bitmap(b, 0,0,640,256, 
-            //                         current_elk_window.startx, current_elk_window.starty,
-            //                         current_elk_window.winsizex,current_elk_window.winsizey, 0);
-            //blit(b,b162,0,0,0,0,640,256);
+        case _2XSAI:
             Super2xSaI(elk_screen_data,b16,640,256);
             if(elkConfig.stats.blitting_performance_stats)
             {
@@ -543,8 +511,6 @@ void video_blit_to_screen(int drawMode, uint8_t * elk_screen_data)
     }
 
     al_flip_display();
-    endblit();
-
 
     if(elkConfig.stats.blitting_performance_stats)
     {

--- a/src/host_abstraction_layer/allegro_5/video_internal.h
+++ b/src/host_abstraction_layer/allegro_5/video_internal.h
@@ -43,8 +43,8 @@ void video_mouse_event();
 bool video_is_main_display(ALLEGRO_DISPLAY * current_display);
 
 int Init_2xSaI(int depth);
-void Super2xSaI(uint8_t * elk_screen_data, ALLEGRO_BITMAP * bitmapDest, int w, int h);
-void SuperEagle(uint8_t * elk_screen_data, ALLEGRO_BITMAP * bitmapDest, int w, int h);
+void Super2xSaI(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, uint32 height);
+void SuperEagle(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, uint32 height);
 
 // Other filer routines.
 void scale2x(uint8_t * elk_screen_data, ALLEGRO_BITMAP * bitmapDest, int width, int height);
@@ -52,7 +52,6 @@ void scale2x(uint8_t * elk_screen_data, ALLEGRO_BITMAP * bitmapDest, int width, 
 void initpaltables();
 void palfilter(ALLEGRO_BITMAP * destBitmap, uint8_t * elk_screen_data);
 
-void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, uint32 height);
-void SuperEagle_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, uint32 height);
+
 
 #endif // _VIDEO_INTERNAL_H

--- a/src/host_abstraction_layer/allegro_5/video_internal.h
+++ b/src/host_abstraction_layer/allegro_5/video_internal.h
@@ -44,7 +44,7 @@ bool video_is_main_display(ALLEGRO_DISPLAY * current_display);
 
 int Init_2xSaI(int depth);
 void Super2xSaI(uint8_t * elk_screen_data, ALLEGRO_BITMAP * bitmapDest, int w, int h);
-void SuperEagle(ALLEGRO_BITMAP * bitmapSource, ALLEGRO_BITMAP * bitmapDest, int s_x, int s_y, int d_x, int d_y, int w, int h);
+void SuperEagle(uint8_t * elk_screen_data, ALLEGRO_BITMAP * bitmapDest, int w, int h);
 
 // Other filer routines.
 void scale2x(uint8_t * elk_screen_data, ALLEGRO_BITMAP * bitmapDest, int width, int height);
@@ -53,6 +53,6 @@ void initpaltables();
 void palfilter(ALLEGRO_BITMAP * destBitmap, uint8_t * elk_screen_data);
 
 void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, uint32 height);
-void SuperEagle_ex(uint8 *src, uint32 src_pitch, uint8 *unused, ALLEGRO_BITMAP *dest, uint32 width, uint32 height);
+void SuperEagle_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, uint32 height);
 
 #endif // _VIDEO_INTERNAL_H

--- a/src/host_abstraction_layer/allegro_5/video_internal.h
+++ b/src/host_abstraction_layer/allegro_5/video_internal.h
@@ -43,7 +43,7 @@ void video_mouse_event();
 bool video_is_main_display(ALLEGRO_DISPLAY * current_display);
 
 int Init_2xSaI(int depth);
-void Super2xSaI(ALLEGRO_BITMAP * bitmapDest, uint8_t * elk_screen_data, int s_x, int s_y, int d_x, int d_y, int w, int h);
+void Super2xSaI(ALLEGRO_BITMAP * bitmapDest, uint8_t * elk_screen_data, int w, int h);
 void SuperEagle(ALLEGRO_BITMAP * bitmapSource, ALLEGRO_BITMAP * bitmapDest, int s_x, int s_y, int d_x, int d_y, int w, int h);
 
 // Other filer routines.
@@ -52,7 +52,7 @@ void scale2x(uint8_t * elk_screen_data, ALLEGRO_BITMAP * bitmapDest, int width, 
 void initpaltables();
 void palfilter(ALLEGRO_BITMAP * destBitmap, uint8_t * elk_screen_data);
 
-void Super2xSaI_ex(uint8_t * elk_screen_data, uint32 src_pitch, uint8 *unused, ALLEGRO_BITMAP *dest, uint32 width, uint32 height);
+void Super2xSaI_ex(uint8_t * elk_screen_data, ALLEGRO_BITMAP *dest, uint32 width, uint32 height);
 void SuperEagle_ex(uint8 *src, uint32 src_pitch, uint8 *unused, ALLEGRO_BITMAP *dest, uint32 width, uint32 height);
 
 #endif // _VIDEO_INTERNAL_H

--- a/src/host_abstraction_layer/allegro_5/video_internal.h
+++ b/src/host_abstraction_layer/allegro_5/video_internal.h
@@ -43,7 +43,7 @@ void video_mouse_event();
 bool video_is_main_display(ALLEGRO_DISPLAY * current_display);
 
 int Init_2xSaI(int depth);
-void Super2xSaI(ALLEGRO_BITMAP * bitmapDest, uint8_t * elk_screen_data, int w, int h);
+void Super2xSaI(uint8_t * elk_screen_data, ALLEGRO_BITMAP * bitmapDest, int w, int h);
 void SuperEagle(ALLEGRO_BITMAP * bitmapSource, ALLEGRO_BITMAP * bitmapDest, int s_x, int s_y, int d_x, int d_y, int w, int h);
 
 // Other filer routines.

--- a/src/host_abstraction_layer/native_time.h
+++ b/src/host_abstraction_layer/native_time.h
@@ -51,7 +51,7 @@ native_timediff_t native_cumulative_time_adjust(native_timediff_t offset, native
 void native_timediff_sprintf(char * diff_string, size_t diff_string_length, native_timediff_t timediff);
 native_timestamp_t native_timestamp_get();
 
-void log_timer_begin();
+void log_timer_begin(const char *msg);
 void log_time_mark(const char *msg);
 void log_time_display();
 

--- a/src/main.c
+++ b/src/main.c
@@ -459,7 +459,7 @@ int main(int argc, char *argv[])
                         skip_video_refresh = true;
                         pause_video_blit(); // We don't need to update the screen for this (helps on slower machines).
                     }
-                    elk_runtime += runelk(skip_video_refresh);
+                    elk_runtime += runelk();
                     count--;
                 }
                 resume_video_blit();

--- a/src/main.c
+++ b/src/main.c
@@ -182,6 +182,7 @@ void initelk(int argc, char *argv[])
         {
             romnext=-1;
         }
+#ifndef WIN32
         else if (!strcasecmp(argv[c],"-parallel"))
         {
             parallelnext=1;
@@ -194,6 +195,7 @@ void initelk(int argc, char *argv[])
         {
             serialdebugnext=1;
         }
+#endif
         else if (!strcasecmp(argv[c],"-debug"))
         {
             debug=debugon=1;
@@ -221,6 +223,7 @@ void initelk(int argc, char *argv[])
                 romnext = -2;
             }
         }
+#ifndef WIN32
         else if (parallelnext)
         {
             strcpy(parallelname,argv[c]);
@@ -236,6 +239,7 @@ void initelk(int argc, char *argv[])
             serial_debug = atoi(argv[c]);
             serialdebugnext=0;
         }
+#endif
         if (tapenext) tapenext--;
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -356,7 +356,7 @@ void native_window_close_button_handler(void)
 * Public Function Definitions
 *******************************************************************************/
 
-int main(int argc, char *argv[])
+int main(int argc, char **argv)
 {
     int count = 0;
     //init_config(); TODO: May need this not sure.

--- a/tools/serial_client.py
+++ b/tools/serial_client.py
@@ -46,7 +46,7 @@ def cr_to_lf(s):
     containing line feeds, replacing carriage returns.
     """
 
-    return s.replace("\n", "").replace("\r", "\n")
+    return s.replace(b"\n", b"").replace(b"\r", b"\n")
 
 def lf_to_cr(s):
 
@@ -55,7 +55,7 @@ def lf_to_cr(s):
     containing carriage returns, replacing line feeds.
     """
 
-    return s.replace("\r", "").replace("\n", "\r")
+    return s.replace(b"\r", b"").replace(b"\n", b"\r")
 
 # Communications functions.
 
@@ -67,12 +67,12 @@ def session(poller, channels):
         fds = poller.poll()
         for fd, status in fds:
             if status & (select.POLLHUP | select.POLLNVAL | select.POLLERR):
-                print >>sys.stderr, "Connection closed."
+                print("Connection closed.", file=sys.stderr)
                 return
             elif status & select.POLLIN:
                 reader, writer, converter = channels[fd]
                 s = converter(reader.read(1))
-                writer.write(s)
+                writer.write(s.decode('utf-8'))
 
 def main():
 
@@ -98,16 +98,16 @@ def main():
 
     # Accept a connection.
 
-    print >>sys.stderr, "Waiting for connection at:", filename
+    print("Waiting for connection at:", filename, file=sys.stderr)
 
     c, addr = s.accept()
 
-    print >>sys.stderr, "Connection accepted."
+    print("Connection accepted.", file=sys.stderr)
 
     # Employ file-like objects for reading and writing.
 
-    reader = c.makefile("r", 0)
-    writer = c.makefile("w", 0)
+    reader = c.makefile("rb", 0)
+    writer = c.makefile("wb", 0)
 
     # Employ polling on the socket input and on standard input.
 


### PR DESCRIPTION
- Updated serial python script to python3 (python2 is now deprecated).
- Serial and parallel working on linux
- Windows Serial and parallel implementation is explicitly disabled for now (used linux sockets which are not available / hard to implement on Windows.  This is the same functionality that was available prior to updates to Allegro5, etc).
- Remove Ubuntu 20.04 build from gitlab actions (Ubuntu 20.04 is now deprecated and out of support).
- 2xSai video filter now working and selectable.
- Eagle video filter still to do updated but incorrectly rendering (looks like an algorithm regression).
