### PR TITLE
Joystick joydev support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 /src/host_abstraction_layer/allegro_4/.dirstamp
 /src/host_abstraction_layer/allegro_5/.dirstamp
 /src/host_abstraction_layer/common/.dirstamp
+/.idea
+/games
+/build/config.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -46,6 +46,7 @@ elkulator_hal_src = src/host_abstraction_layer/allegro_5/adc.c  \
                     src/host_abstraction_layer/allegro_5/fileutils.c \
                     src/host_abstraction_layer/allegro_5/hal.c \
                     src/host_abstraction_layer/allegro_5/joystick_handler.c \
+                    src/host_abstraction_layer/allegro_5/joydev.c \
                     src/host_abstraction_layer/allegro_5/key_handler.c \
                     src/host_abstraction_layer/allegro_5/menus.c \
                     src/host_abstraction_layer/allegro_5/menu_file.c \

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Elkulator is licensed under the GPL, see COPYING for more details.
 
 # ROMs
 
-The basic ROMs for emulation are included with the source.
+**The basic ROMs for emulation are included with the source.**
 
 However, if for some reason they are missing the the ROMs required by Elkulator can be
 obtained from the 1.0 release of the emulator, available from 
@@ -62,7 +62,7 @@ If this is successful then you should be able to run the emulator:
   ./elkulator.exe
 ```
  
-## Linux (Ubuntu and debian based distros)
+## Linux (Ubuntu and Debian based distros)
 
 You will need the following libraries:
 
@@ -76,8 +76,15 @@ following command in a terminal window:
 
 ```
   sudo apt-get update
-  sudo apt-get install automake liballegro5-dev zlib1g-dev libalut-dev libopenal-dev 
+  sudo apt-get install automake liballegro5-dev liballegro-acodec5-dev \
+    liballegro-audio5-dev liballegro-dialog5-dev liballegro-image5-dev \
+    zlib1g-dev libalut-dev libopenal-dev
 ```
+
+(The acodec, audio, dialog and image addon `-dev` packages are only
+`Recommends` of `liballegro5-dev`, so they are pulled in automatically by a
+default apt configuration but skipped under `--no-install-recommends`. They are
+listed explicitly above so the build works regardless of your apt settings.)
 
 To configure and build Elkulator, open a terminal window, navigate to the
 Elkulator directory then enter
@@ -107,12 +114,11 @@ You will need the following libraries:
 - ALut
 - Zlib
 
-On a Debian system you should be able to install these by invoking the
+On a Fedora system you should be able to install these by invoking the
 following command in a terminal window:
 
 ```
-  sudo apt-get update
-  sudo apt-get install automake allegro5-devel allegro5-addon-dialog-devel allegro5-addon-audio-devel allegro5-addon-acodec-devel allegro5-addon-image-devel allegro5-addon-video-devel openal-devel freealut-devel zlib-devel 
+  sudo dnf install automake allegro5-devel allegro5-addon-dialog-devel allegro5-addon-audio-devel allegro5-addon-acodec-devel allegro5-addon-image-devel allegro5-addon-video-devel openal-devel freealut-devel zlib-devel 
 ```
 
 To configure and build Elkulator, open a terminal window, navigate to the

--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ else
 fi
 
 AC_MSG_CHECKING([whether to use legacy allegro4])
-AC_ARG_ENABLE(allergo4,
+AC_ARG_ENABLE(allegro4,
 	      AC_HELP_STRING([--enable-allegro4], [use allegro4 to build]))
 if test "$enable_allegro4" = "yes"; then
    CFLAGS="$CFLAGS -DHAL_ALLEGRO_4"

--- a/src/host_abstraction_layer/allegro_5/adc.c
+++ b/src/host_abstraction_layer/allegro_5/adc.c
@@ -2,6 +2,8 @@
   ADC / Plus 1 emulation*/
 #include <allegro5/allegro.h>
 #include "elk.h"
+#include "config_vars.h"
+#include "joydev.h"
 
 uint8_t plus1stat=0x7F;
 
@@ -11,34 +13,40 @@ uint8_t adcdat;
 void writeadc(uint8_t val)
 {
         int dat1=0,dat2=0;
-//        if (!num_joysticks) num_joysticks++;
-//        plus1stat|=0x40;
-//        adctime=80;
-//        switch (val&3)
-//        {
-//                case 0: dat1=-joy[elkConfig.expansion.joffset%num_joysticks].stick[0].axis[0].pos; break;
-//                case 1: dat1=-joy[elkConfig.expansion.joffset%num_joysticks].stick[0].axis[1].pos; break;
-//                case 2: dat1=-joy[(elkConfig.expansion.joffset+1)%num_joysticks].stick[0].axis[0].pos; break;
-//                case 3: dat1=-joy[(elkConfig.expansion.joffset+1)%num_joysticks].stick[0].axis[1].pos; break;
-//        }
-//        switch (val&0xC)
-//        {
-//                case 0: case 8:
-//                switch (val&3)
-//                {
-//                        case 0: dat2=-joy[elkConfig.expansion.joffset%num_joysticks].stick[0].axis[1].pos; break;
-//                        case 1: dat2=-joy[elkConfig.expansion.joffset%num_joysticks].stick[0].axis[0].pos; break;
-//                        case 2: dat2=-joy[(elkConfig.expansion.joffset+1)%num_joysticks].stick[0].axis[1].pos; break;
-//                        case 3: dat2=-joy[(elkConfig.expansion.joffset+1)%num_joysticks].stick[0].axis[0].pos; break;
-//                }
-//                break;
-//                case 4: dat2=0; break;
-//                case 12: dat2=-joy[(elkConfig.expansion.joffset+1)%num_joysticks].stick[0].axis[1].pos; break;
-//        }
-//        if (dat1>127) dat1=127;
-//        if (dat1<-128) dat1=-128;
-//        if (dat2>127) dat2=127;
-//        if (dat2<-128) dat2=-128;
+        joydev_poll();
+        int n=joydev_num_joysticks();
+        plus1stat|=0x40;
+        adctime=80;
+        if (n>0)
+        {
+                int j0=elkConfig.expansion.joffset%n;
+                int j1=(elkConfig.expansion.joffset+1)%n;
+                switch (val&3)
+                {
+                        case 0: dat1=-joydev_get_axis(j0,0); break;
+                        case 1: dat1=-joydev_get_axis(j0,1); break;
+                        case 2: dat1=-joydev_get_axis(j1,0); break;
+                        case 3: dat1=-joydev_get_axis(j1,1); break;
+                }
+                switch (val&0xC)
+                {
+                        case 0: case 8:
+                        switch (val&3)
+                        {
+                                case 0: dat2=-joydev_get_axis(j0,1); break;
+                                case 1: dat2=-joydev_get_axis(j0,0); break;
+                                case 2: dat2=-joydev_get_axis(j1,1); break;
+                                case 3: dat2=-joydev_get_axis(j1,0); break;
+                        }
+                        break;
+                        case 4: dat2=0; break;
+                        case 12: dat2=-joydev_get_axis(j1,1); break;
+                }
+                if (dat1>127) dat1=127;
+                if (dat1<-128) dat1=-128;
+                if (dat2>127) dat2=127;
+                if (dat2<-128) dat2=-128;
+        }
         adcdat=(dat1-dat2)+128;
 //        rpclog("ADC conv %02X %i %i %02X\n",val,dat1,dat2,adcdat);
 }
@@ -51,9 +59,15 @@ uint8_t readadc()
 uint8_t getplus1stat()
 {
         int c;
-//        if (!num_joysticks) num_joysticks++;
+        joydev_poll();
+        int n=joydev_num_joysticks();
         plus1stat|=0x30;
-//        for (c=0;c<joy[elkConfig.expansion.joffset%num_joysticks].num_buttons;c++) if (joy[elkConfig.expansion.joffset%num_joysticks].button[c].b) plus1stat&=~0x10;
-//        for (c=0;c<joy[(elkConfig.expansion.joffset+1)%num_joysticks].num_buttons;c++) if (joy[(elkConfig.expansion.joffset+1)%num_joysticks].button[c].b) plus1stat&=~0x20;
+        if (n>0)
+        {
+                int j0=elkConfig.expansion.joffset%n;
+                int j1=(elkConfig.expansion.joffset+1)%n;
+                for (c=0;c<joydev_num_buttons(j0);c++) if (joydev_get_button(j0,c)) plus1stat&=~0x10;
+                for (c=0;c<joydev_num_buttons(j1);c++) if (joydev_get_button(j1,c)) plus1stat&=~0x20;
+        }
         return plus1stat;
 }

--- a/src/host_abstraction_layer/allegro_5/firstbyte.c
+++ b/src/host_abstraction_layer/allegro_5/firstbyte.c
@@ -3,16 +3,22 @@
 #include <allegro5/allegro.h>
 
 #include "config_vars.h"
+#include "joydev.h"
 
 uint8_t readfirstbyte()
 {
-//        int c;
+        int c;
         uint8_t temp=0xFF;
-//        if (!num_joysticks) num_joysticks++;
-//        if (joy[elkConfig.expansion.joffset%num_joysticks].stick[0].axis[1].pos<-32) temp&=~0x01;
-//        if (joy[elkConfig.expansion.joffset%num_joysticks].stick[0].axis[1].pos>=32) temp&=~0x02;
-//        if (joy[elkConfig.expansion.joffset%num_joysticks].stick[0].axis[0].pos<-32) temp&=~0x04;
-//        if (joy[elkConfig.expansion.joffset%num_joysticks].stick[0].axis[0].pos>=32) temp&=~0x08;
-//        for (c=0;c<joy[elkConfig.expansion.joffset%num_joysticks].num_buttons;c++) if (joy[elkConfig.expansion.joffset%num_joysticks].button[c].b) temp&=~0x10;
+        joydev_poll();
+        int n=joydev_num_joysticks();
+        if (n>0)
+        {
+                int j=elkConfig.expansion.joffset%n;
+                if (joydev_get_axis(j,1)<-32) temp&=~0x01;
+                if (joydev_get_axis(j,1)>=32) temp&=~0x02;
+                if (joydev_get_axis(j,0)<-32) temp&=~0x04;
+                if (joydev_get_axis(j,0)>=32) temp&=~0x08;
+                for (c=0;c<joydev_num_buttons(j);c++) if (joydev_get_button(j,c)) temp&=~0x10;
+        }
         return temp;
 }

--- a/src/host_abstraction_layer/allegro_5/joydev.c
+++ b/src/host_abstraction_layer/allegro_5/joydev.c
@@ -1,0 +1,160 @@
+/* Elkulator - Linux joydev joystick reader (Allegro 5 backend)
+ *
+ * See joydev.h for rationale.  We read /dev/input/jsN via the kernel joydev
+ * interface (struct js_event), the same path the Allegro 4 build relies on.
+ */
+#define _GNU_SOURCE
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <linux/joystick.h>
+
+#include "logger.h"
+#include "joydev.h"
+
+#define JOYDEV_MAX_STICKS   4
+#define JOYDEV_MAX_AXES     8
+#define JOYDEV_MAX_BUTTONS  32
+#define JOYDEV_SCAN_NODES   32   /* probe /dev/input/js0 .. js31 */
+
+typedef struct
+{
+    int      fd;
+    char     name[128];
+    uint8_t  num_axes;
+    uint8_t  num_buttons;
+    int      axis[JOYDEV_MAX_AXES];       /* scaled to -128..127  */
+    uint8_t  button[JOYDEV_MAX_BUTTONS];  /* 0 = up, 1 = pressed  */
+} joydev_stick_t;
+
+static joydev_stick_t sticks[JOYDEV_MAX_STICKS];
+static int  num_sticks  = 0;
+static bool initialised = false;
+
+/* keyd and similar tools expose pointer devices that also create a jsN node.
+ * Those are not real joysticks, so skip anything that names itself as one. */
+static bool looks_like_pointer(const char *name)
+{
+    return strcasestr(name, "mouse") != NULL ||
+           strcasestr(name, "pointer") != NULL ||
+           strcasestr(name, "trackpad") != NULL;
+}
+
+static void open_one(const char *path)
+{
+    if (num_sticks >= JOYDEV_MAX_STICKS)
+        return;
+
+    int fd = open(path, O_RDONLY | O_NONBLOCK);
+    if (fd < 0)
+        return;
+
+    char name[128] = "Unknown";
+    char axes = 0, btns = 0;
+    ioctl(fd, JSIOCGNAME(sizeof(name)), name);
+    ioctl(fd, JSIOCGAXES, &axes);
+    ioctl(fd, JSIOCGBUTTONS, &btns);
+
+    if (axes == 0 || looks_like_pointer(name))
+    {
+        log_info("joydev: skipping %s ('%s', axes=%d)\n", path, name, axes);
+        close(fd);
+        return;
+    }
+
+    joydev_stick_t *s = &sticks[num_sticks];
+    memset(s, 0, sizeof(*s));
+    s->fd = fd;
+    strncpy(s->name, name, sizeof(s->name) - 1);
+    s->num_axes    = (axes > JOYDEV_MAX_AXES)    ? JOYDEV_MAX_AXES    : (uint8_t)axes;
+    s->num_buttons = (btns > JOYDEV_MAX_BUTTONS) ? JOYDEV_MAX_BUTTONS : (uint8_t)btns;
+
+    log_info("joydev: stick %d = '%s' (%s) axes=%d buttons=%d\n",
+             num_sticks, s->name, path, s->num_axes, s->num_buttons);
+    num_sticks++;
+}
+
+void joydev_init(void)
+{
+    if (initialised)
+        return;
+    initialised = true;
+    num_sticks  = 0;
+
+    char path[32];
+    for (int i = 0; i < JOYDEV_SCAN_NODES && num_sticks < JOYDEV_MAX_STICKS; i++)
+    {
+        snprintf(path, sizeof(path), "/dev/input/js%d", i);
+        if (access(path, R_OK) == 0)
+            open_one(path);
+    }
+
+    if (num_sticks == 0)
+        log_info("joydev: no joysticks found\n");
+}
+
+void joydev_poll(void)
+{
+    if (!initialised)
+        joydev_init();
+
+    struct js_event e;
+    for (int i = 0; i < num_sticks; i++)
+    {
+        joydev_stick_t *s = &sticks[i];
+        while (read(s->fd, &e, sizeof(e)) == (ssize_t)sizeof(e))
+        {
+            uint8_t type = e.type & ~JS_EVENT_INIT;
+            if (type == JS_EVENT_AXIS && e.number < JOYDEV_MAX_AXES)
+            {
+                /* joydev axis range is -32767..32767; scale to -128..127 */
+                int v = e.value / 256;
+                if (v >  127) v =  127;
+                if (v < -128) v = -128;
+                s->axis[e.number] = v;
+            }
+            else if (type == JS_EVENT_BUTTON && e.number < JOYDEV_MAX_BUTTONS)
+            {
+                s->button[e.number] = e.value ? 1 : 0;
+            }
+        }
+    }
+}
+
+int joydev_num_joysticks(void)
+{
+    return num_sticks;
+}
+
+int joydev_get_axis(int joy, int axis)
+{
+    if (joy < 0 || joy >= num_sticks)        return 0;
+    if (axis < 0 || axis >= JOYDEV_MAX_AXES) return 0;
+    return sticks[joy].axis[axis];
+}
+
+int joydev_num_buttons(int joy)
+{
+    if (joy < 0 || joy >= num_sticks) return 0;
+    return sticks[joy].num_buttons;
+}
+
+int joydev_get_button(int joy, int btn)
+{
+    if (joy < 0 || joy >= num_sticks)          return 0;
+    if (btn < 0 || btn >= JOYDEV_MAX_BUTTONS)  return 0;
+    return sticks[joy].button[btn];
+}
+
+void joydev_shutdown(void)
+{
+    for (int i = 0; i < num_sticks; i++)
+        if (sticks[i].fd >= 0)
+            close(sticks[i].fd);
+    num_sticks  = 0;
+    initialised = false;
+}

--- a/src/host_abstraction_layer/allegro_5/joydev.h
+++ b/src/host_abstraction_layer/allegro_5/joydev.h
@@ -1,0 +1,34 @@
+/* Elkulator - Linux joydev joystick reader (Allegro 5 backend)
+ *
+ * Allegro 5's joystick driver does not enumerate some devices (e.g. the
+ * CM5 uConsole pad) that the kernel exposes via /dev/input/jsN.  This small
+ * module reads the legacy joydev interface directly, mirroring what the
+ * Allegro 4 build did internally, and feeds the ADC / First Byte emulation.
+ */
+#ifndef _JOYDEV_H
+#define _JOYDEV_H
+
+/* Open available joysticks.  Safe to call more than once (no-op after the
+ * first successful call).  Called lazily by joydev_poll() if not already done. */
+void joydev_init(void);
+
+/* Drain pending events from all open joysticks and update cached state.
+ * Cheap (non-blocking reads); call before reading axis/button state. */
+void joydev_poll(void);
+
+/* Number of usable joysticks detected (pointer-like devices excluded). */
+int  joydev_num_joysticks(void);
+
+/* Axis position scaled to -128..127 (0 if joy/axis out of range). */
+int  joydev_get_axis(int joy, int axis);
+
+/* Number of buttons on the given joystick (0 if out of range). */
+int  joydev_num_buttons(int joy);
+
+/* Button state: 1 = pressed, 0 = released / out of range. */
+int  joydev_get_button(int joy, int btn);
+
+/* Close all joystick file descriptors. */
+void joydev_shutdown(void);
+
+#endif /* _JOYDEV_H */

--- a/src/host_abstraction_layer/allegro_5/joystick_internal.h
+++ b/src/host_abstraction_layer/allegro_5/joystick_internal.h
@@ -5,6 +5,7 @@
 #include <allegro5/allegro.h>
 #include "host_abstraction_layer/event_handler.h"
 
+void joystick_init(void);
 elk_event_t joystick_handler_handle_event(ALLEGRO_EVENT *event);
 
 # endif // _JOYSTICK_INTERNAL_H

--- a/src/host_abstraction_layer/allegro_5/menu_settings.c
+++ b/src/host_abstraction_layer/allegro_5/menu_settings.c
@@ -43,6 +43,10 @@ elk_event_t menu_handle_toggle_paged_ram_jim(ALLEGRO_EVENT * event);
 elk_event_t menu_handle_plus_3_enable(ALLEGRO_EVENT * event);
 elk_event_t menu_handle_adfs_enable(ALLEGRO_EVENT * event);
 elk_event_t menu_handle_dfs_enable(ALLEGRO_EVENT * event);
+
+elk_event_t menu_handle_joystick_plus1_enable(ALLEGRO_EVENT * event);
+elk_event_t menu_handle_joystick_firstbyte_enable(ALLEGRO_EVENT * event);
+
 elk_event_t menu_redefine_keyboard(ALLEGRO_EVENT * event);
 
 /******************************************************************************
@@ -170,8 +174,8 @@ static ALLEGRO_MENU *create_settings_disc_menu(void)
 static ALLEGRO_MENU *create_settings_joystick_menu(void)
 {
     ALLEGRO_MENU *menu = al_create_menu();
-    al_append_menu_item(menu, "Plus 1 joystick interface",     IDM_SETTINGS_JOYSTICK_PLUS1, ALLEGRO_MENU_ITEM_DISABLED, NULL, NULL);
-    al_append_menu_item(menu, "First Byte joystick interface", IDM_SETTINGS_JOYSTICK_FIRSTBYTE,  ALLEGRO_MENU_ITEM_DISABLED, NULL, NULL);
+    add_checkbox_item(menu, "Plus 1 joystick interface",     IDM_SETTINGS_JOYSTICK_PLUS1,     elkConfig.expansion.plus1,     menu_handle_joystick_plus1_enable);
+    add_checkbox_item(menu, "First Byte joystick interface", IDM_SETTINGS_JOYSTICK_FIRSTBYTE, elkConfig.expansion.firstbyte, menu_handle_joystick_firstbyte_enable);
     return menu;
 }
 
@@ -378,6 +382,21 @@ elk_event_t menu_handle_dfs_enable(ALLEGRO_EVENT * event)
         al_set_menu_item_flags(menu, IDM_SETTINGS_DISC_ADFS_ENABLE, ALLEGRO_MENU_ITEM_CHECKBOX);
     }
     return(ELK_EVENT_RESET);
+}
+
+// Called when IDM_SETTINGS_JOYSTICK_PLUS1 event is recieved.
+elk_event_t menu_handle_joystick_plus1_enable(ALLEGRO_EVENT * event)
+{
+    // Plus 1 needs its ROM paged in, so reset to (re)initialise memory.
+    elkConfig.expansion.plus1 = !elkConfig.expansion.plus1;
+    return(ELK_EVENT_RESET);
+}
+
+// Called when IDM_SETTINGS_JOYSTICK_FIRSTBYTE event is recieved.
+elk_event_t menu_handle_joystick_firstbyte_enable(ALLEGRO_EVENT * event)
+{
+    elkConfig.expansion.firstbyte = !elkConfig.expansion.firstbyte;
+    return(ELK_EVENT_NONE);
 }
 
 elk_event_t menu_redefine_keyboard(ALLEGRO_EVENT * event)

--- a/src/host_abstraction_layer/allegro_5/video.c
+++ b/src/host_abstraction_layer/allegro_5/video.c
@@ -36,6 +36,8 @@
 #include "elk.h"
 #include "video_internal.h"
 #include "event_handler_internal.h"
+#include "joystick_internal.h"
+#include "joydev.h"
 
 /******************************************************************************
 * Preprocessor Macros
@@ -168,7 +170,11 @@ int video_init_begin()
     }
 
     joystick_init();
-    
+
+    /* Allegro 5's joystick driver misses some kernel joydev devices
+     * (e.g. the CM5 uConsole pad), so also enumerate /dev/input/jsN directly. */
+    joydev_init();
+
     if (!al_install_keyboard())
     {
         log_fatal("main: unable to install keyboard");


### PR DESCRIPTION
## Summary

Adds joystick support to the Allegro 5 backend, including a direct Linux joydev reader and the menu items to enable the Plus 1 / First Byte joystick interfaces.

## Changes

- **Direct Linux joydev reader** (`joydev.c`/`joydev.h`) — reads joystick axes/buttons straight from the Linux `/dev/input/jsX` device for the Allegro 5 backend.
- **Joystick initialisation & event handling** — joystick detection, initialisation, and event wiring (`joystick_handler.c`, `joystick_internal.h`, `event_handler.c`).
- **Plus 1 / First Byte interface menu items** — enabled in `menu_settings.c`, with supporting changes in `adc.c`, `firstbyte.c`, `hal.c`, and `video.c`.

## Commits

- Basic joystick initialisation, detection, and event handling added
- Proper initialisation of joystick work begun
- Add direct Linux joydev joystick reader for Allegro 5 backend
- Enable Plus 1 / First Byte joystick interface menu items

## Test plan

- [ ] Build the Allegro 5 backend and confirm a connected joystick is detected
- [ ] Verify Plus 1 / First Byte joystick interface menu items toggle correctly
- [ ] Confirm joystick input is read via the Linux joydev path